### PR TITLE
Only scrolls to a newly added Category after immediately adding it (in Settings)

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.willowtree.vocable.settings
 
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
@@ -17,7 +19,14 @@ import com.willowtree.vocable.room.RoomStoredPhrasesRepository
 import com.willowtree.vocable.room.VocableDatabase
 import com.willowtree.vocable.utility.FakeDateProvider
 import com.willowtree.vocable.utility.StubLegacyCategoriesAndPhrasesRepository
+import com.willowtree.vocable.utility.VocableKoinTestRule
+import junit.framework.TestCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -25,7 +34,13 @@ import org.junit.Test
 class EditCategoriesViewModelTest {
 
     @get:Rule
+    val koinTestRule = VocableKoinTestRule()
+
+    @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
 
     private val database = Room.inMemoryDatabaseBuilder(
         ApplicationProvider.getApplicationContext(),
@@ -68,6 +83,107 @@ class EditCategoriesViewModelTest {
         return EditCategoriesViewModel(
             categoriesUseCase
         )
+    }
+
+    // 1. refreshing categories without adding new category remains at first index
+    // 2. adding new category and refreshing once flips to new category's index
+    // 3. adding new category and refreshing twice flips to first index
+    // 4. adding new category amongst hidden categories and refreshing once flips to new category's index (before hidden categories)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun  refreshing_categories_without_adding_new_category_remains_at_first_index() = runTest(UnconfinedTestDispatcher()) {
+        val vm = createViewModel()
+        vm.refreshCategories()
+
+        var index: Int? = null
+        val observer = Observer<Int> { value ->
+            index = value
+        }
+
+        try {
+            vm.lastViewedIndex.observeForever(observer)
+            advanceUntilIdle()
+            assertEquals(0, index)
+        } finally {
+            vm.lastViewedIndex.removeObserver(observer)
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun  adding_new_category_and_refreshing_once_flips_to_new_categorys_index() = runTest(UnconfinedTestDispatcher()) {
+        val vm = createViewModel()
+        vm.refreshCategories()
+
+        categoriesUseCase.addCategory("new category")
+        vm.refreshCategories()
+
+        var index: Int? = null
+        val observer = Observer<Int> { value ->
+            index = value
+        }
+
+        try {
+            vm.lastViewedIndex.observeForever(observer)
+            advanceUntilIdle()
+            assertEquals(7, index)
+        } finally {
+            vm.lastViewedIndex.removeObserver(observer)
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun  adding_new_category_and_refreshing_twice_flips_to_first_index() = runTest(UnconfinedTestDispatcher()) {
+        val vm = createViewModel()
+        vm.refreshCategories()
+
+        categoriesUseCase.addCategory("new category")
+        vm.refreshCategories()
+        vm.refreshCategories()
+
+        var index: Int? = null
+        val observer = Observer<Int> { value ->
+            index = value
+        }
+
+        try {
+            vm.lastViewedIndex.observeForever(observer)
+            advanceUntilIdle()
+            assertEquals(0, index)
+        } finally {
+            vm.lastViewedIndex.removeObserver(observer)
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun  adding_new_category_amongst_hidden_categories_and_refreshing_once_flips_to_last_non_hidden_index() = runTest(UnconfinedTestDispatcher()) {
+        val vm = createViewModel()
+        categoriesUseCase.updateCategoryHidden("preset_general", hidden = true)
+        categoriesUseCase.updateCategoryHidden("preset_basic_needs", hidden = true)
+
+        vm.refreshCategories()
+
+        categoriesUseCase.addCategory("new category")
+
+        categoriesUseCase.categories().first()
+
+        vm.refreshCategories()
+
+        var index: Int? = null
+        val observer = Observer<Int> { value ->
+            index = value
+        }
+
+        try {
+            vm.lastViewedIndex.observeForever(observer)
+            advanceUntilIdle()
+            assertEquals(5, index)
+        } finally {
+            vm.lastViewedIndex.removeObserver(observer)
+        }
     }
 
     @Test

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesFragment.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesFragment.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.willowtree.vocable.BaseFragment
@@ -16,6 +17,7 @@ import com.willowtree.vocable.R
 import com.willowtree.vocable.databinding.FragmentEditCategoriesBinding
 import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.utils.VocableFragmentStateAdapter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ViewModelOwner
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -121,15 +123,12 @@ class EditCategoriesFragment : BaseFragment<FragmentEditCategoriesBinding>() {
             }
         }
 
-        editCategoriesViewModel.lastViewedIndex.observe(viewLifecycleOwner) {
-            it?.let { index ->
-                val pageNum = index / maxEditCategories
-                // Wait until view pager has finished its layout
-                binding.editCategoriesViewPager.post {
+        editCategoriesViewModel.viewModelScope.launch {
+            editCategoriesViewModel.liveLastViewedIndex.collect {
+                val pageNum = it/maxEditCategories
                     if (isAdded && binding.editCategoriesViewPager.currentItem != pageNum) {
                         binding.editCategoriesViewPager.setCurrentItem(pageNum, false)
                     }
-                }
             }
         }
     }

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
@@ -27,7 +27,7 @@ class EditCategoriesViewModel(
 
             overallCategories = categoriesUseCase.categories().first()
 
-            // Check if a new category was added and scroll to it
+            // Check if a new category was added and scroll to it only immediately after added
             if (oldCategories.isNotEmpty() && oldCategories.size < overallCategories.size) {
                 when (val firstHiddenIndex = overallCategories.indexOfFirst { it.hidden }) {
                     -1 -> {
@@ -42,6 +42,9 @@ class EditCategoriesViewModel(
                         liveLastViewedIndex.postValue(firstHiddenIndex - 1)
                     }
                 }
+            }
+            else {
+                liveLastViewedIndex.postValue(0)
             }
         }
     }

--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoriesViewModel.kt
@@ -1,12 +1,12 @@
 package com.willowtree.vocable.settings
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.ICategoriesUseCase
 import com.willowtree.vocable.presets.Category
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class EditCategoriesViewModel(
@@ -15,8 +15,7 @@ class EditCategoriesViewModel(
 
     val categoryList = categoriesUseCase.categories()
 
-    private val liveLastViewedIndex = MutableLiveData<Int>()
-    val lastViewedIndex: LiveData<Int> = liveLastViewedIndex
+    val liveLastViewedIndex =  MutableStateFlow(0)
 
     private var overallCategories = listOf<Category>()
 
@@ -31,20 +30,20 @@ class EditCategoriesViewModel(
             if (oldCategories.isNotEmpty() && oldCategories.size < overallCategories.size) {
                 when (val firstHiddenIndex = overallCategories.indexOfFirst { it.hidden }) {
                     -1 -> {
-                        liveLastViewedIndex.postValue(overallCategories.size - 1)
+                        liveLastViewedIndex.update { overallCategories.size - 1 }
                     }
 
                     0 -> {
-                        liveLastViewedIndex.postValue(0)
+                        liveLastViewedIndex.update { 0 }
                     }
 
                     else -> {
-                        liveLastViewedIndex.postValue(firstHiddenIndex - 1)
+                        liveLastViewedIndex.update { firstHiddenIndex - 1 }
                     }
                 }
             }
             else {
-                liveLastViewedIndex.postValue(0)
+                liveLastViewedIndex.update { 0 }
             }
         }
     }


### PR DESCRIPTION
Description:
Resets `lastViewedIndex` to 0 if a new category was not just recently added. This means that the  "Categories and Phrases" settings page only automatically scrolls to a newly added Category one time: after immediately adding the new Category. If a new Category was not just added, the "Categories and Phrases" settings page brings the user to the first page. 

Also added ViewModel tests. 

Resolves #532

- [x] Acceptance Criteria satisfied
- [ ] Regression Testing
