### PR TITLE
Fix delete phrase bug (#565)

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/settings/EditCategoryPhrasesViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/EditCategoryPhrasesViewModel.kt
@@ -4,14 +4,16 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.IPhrasesUseCase
 import com.willowtree.vocable.presets.Category
 import com.willowtree.vocable.presets.Phrase
 import com.willowtree.vocable.utils.ILocalizedResourceUtility
+import kotlinx.coroutines.launch
 
 class EditCategoryPhrasesViewModel(
     savedStateHandle: SavedStateHandle,
-    phrasesUseCase: IPhrasesUseCase,
+    private val phrasesUseCase: IPhrasesUseCase,
     private val localizedResourceUtility: ILocalizedResourceUtility
 ) : ViewModel() {
 
@@ -20,5 +22,11 @@ class EditCategoryPhrasesViewModel(
 
     fun getCategoryName(category: Category): String {
         return localizedResourceUtility.getTextFromCategory(category)
+    }
+
+    fun deletePhrase(phrase: Phrase) {
+        viewModelScope.launch {
+            phrasesUseCase.deletePhrase(phrase.phraseId)
+        }
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/settings/customcategories/CustomCategoryPhraseViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/settings/customcategories/CustomCategoryPhraseViewModel.kt
@@ -14,4 +14,10 @@ class CustomCategoryPhraseViewModel(
             phrasesUseCase.deletePhrase(phrase.phraseId)
         }
     }
+
+    fun deletePhraseFromCategory(phrase: Phrase) {
+        viewModelScope.launch {
+            phrasesUseCase.deletePhrase(phrase.phraseId)
+        }
+    }
 }


### PR DESCRIPTION
Maybe fixes https://github.com/willowtreeapps/vocable-android/issues/565?
Do not merge without testing. This is AI generated.

Add methods to delete phrases from categories.

* **CustomCategoryPhraseViewModel.kt**
  - Add `deletePhraseFromCategory` method to delete a phrase from a category.
* **EditCategoryPhrasesViewModel.kt**
  - Add `deletePhrase` method to delete a phrase from a category.
  - Update constructor to make `phrasesUseCase` a private property.

