### PR TITLE
#611: Fix Numbers preset category grid shape and keypad ordering

### DIFF
--- a/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
@@ -39,6 +39,7 @@ class CategoriesUseCaseTest {
     private val storedCategoriesRepository = RoomStoredCategoriesRepository(database)
     private val presetPhrasesRepository = RoomPresetPhrasesRepository(
         database.presetPhrasesDao(),
+        database.phraseDao(),
         dateProvider
     )
     private val storedPhrasesRepository = RoomStoredPhrasesRepository(

--- a/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -36,6 +36,7 @@ class PhrasesUseCaseTest {
     private val dateProvider = FakeDateProvider()
     private val presetPhrasesRepository = RoomPresetPhrasesRepository(
         presetPhrasesDao = database.presetPhrasesDao(),
+        phraseDao = database.phraseDao(),
         dateProvider = dateProvider,
     )
     private val storedPhrasesRepository = RoomStoredPhrasesRepository(database, dateProvider)

--- a/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
@@ -6,9 +6,10 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.willowtree.vocable.domain.model.PresetCategories
 import com.willowtree.vocable.domain.model.PresetPhrase
+import com.willowtree.vocable.core.locale.LocalesWithText
 import com.willowtree.vocable.data.repository.RoomPresetPhrasesRepository
+import com.willowtree.vocable.data.room.PhraseDto
 import com.willowtree.vocable.data.room.PresetPhraseDto
-import com.willowtree.vocable.data.room.PresetPhrasesDao
 import com.willowtree.vocable.data.room.VocableDatabase
 import com.willowtree.vocable.utility.FakeDateProvider
 import com.willowtree.vocable.utility.VocableKoinTestRule
@@ -24,16 +25,17 @@ class RoomPresetPhrasesRepositoryTest {
     @get:Rule
     val vocableKoinTestRule = VocableKoinTestRule()
 
-    private fun createDao(): PresetPhrasesDao = Room.inMemoryDatabaseBuilder(
+    private fun createDatabase(): VocableDatabase = Room.inMemoryDatabaseBuilder(
         ApplicationProvider.getApplicationContext(),
         VocableDatabase::class.java
-    ).build().presetPhrasesDao()
+    ).build()
 
     private fun createRepository(
-        dao: PresetPhrasesDao = createDao()
+        database: VocableDatabase = createDatabase()
     ): RoomPresetPhrasesRepository {
         return RoomPresetPhrasesRepository(
-            presetPhrasesDao = dao,
+            presetPhrasesDao = database.presetPhrasesDao(),
+            phraseDao = database.phraseDao(),
             dateProvider = FakeDateProvider()
         )
     }
@@ -69,7 +71,8 @@ class RoomPresetPhrasesRepositoryTest {
 
     @Test
     fun given_a_phrase_seeded_with_a_stale_sort_order_populateDatabase_resyncs_it() = runTest {
-        val dao = createDao()
+        val database = createDatabase()
+        val dao = database.presetPhrasesDao()
         // A phrase seeded by an earlier release, before R.array.category_123 was reordered into
         // phone-keypad order. Without a resync the array is only the source of truth on a fresh
         // install and the reorder is invisible to anyone who already ran the app - see #611.
@@ -85,7 +88,7 @@ class RoomPresetPhrasesRepositoryTest {
             )
         )
 
-        createRepository(dao).populateDatabase()
+        createRepository(database).populateDatabase()
 
         val keypadPhrase = dao.getPhrase("category_123_0")!!
         assertEquals(9, keypadPhrase.sortOrder)
@@ -96,8 +99,8 @@ class RoomPresetPhrasesRepositoryTest {
 
     @Test
     fun given_a_stale_phrase_populateDatabase_does_not_duplicate_or_misorder_the_category() = runTest {
-        val dao = createDao()
-        dao.insertPhrases(
+        val database = createDatabase()
+        database.presetPhrasesDao().insertPhrases(
             listOf(
                 PresetPhraseDto(
                     phraseId = "category_123_0",
@@ -109,7 +112,7 @@ class RoomPresetPhrasesRepositoryTest {
             )
         )
 
-        val repository = createRepository(dao)
+        val repository = createRepository(database)
         repository.populateDatabase()
 
         // Newly inserted phrases take their array index too, so they can't collide with the
@@ -119,6 +122,45 @@ class RoomPresetPhrasesRepositoryTest {
             repository.getPhrasesForCategory(PresetCategories.USER_KEYPAD.id)
                 .sortedBy { it.sortOrder }
         )
+    }
+
+    @Test
+    fun given_an_edited_preset_populateDatabase_resyncs_the_stored_shadow_phrase() = runTest {
+        val database = createDatabase()
+        // What an install that edited the "0" key before the reorder looks like: the preset row is
+        // soft-deleted and a stored phrase shadows it, both carrying the pre-reorder index. The
+        // shadow has to be renumbered alongside the preset, or the two disagree and the category
+        // renders with a duplicated sort order - and one phrase too many for its page.
+        database.presetPhrasesDao().insertPhrases(
+            listOf(
+                PresetPhraseDto(
+                    phraseId = "category_123_0",
+                    parentCategoryId = PresetCategories.USER_KEYPAD.id,
+                    creationDate = 0L,
+                    lastSpokenDate = null,
+                    sortOrder = 0,
+                )
+            )
+        )
+        database.presetPhrasesDao().deletePhrase("category_123_0", deleted = true)
+        database.phraseDao().insertPhrase(
+            PhraseDto(
+                phraseId = "category_123_0",
+                parentCategoryId = PresetCategories.USER_KEYPAD.id,
+                creationDate = 0L,
+                lastSpokenDate = 1234L,
+                localizedUtterance = LocalesWithText(mapOf("en" to "zero")),
+                sortOrder = 0,
+            )
+        )
+
+        createRepository(database).populateDatabase()
+
+        val shadow = database.phraseDao().getPhrase("category_123_0")!!
+        assertEquals(9, shadow.sortOrder)
+        // The resync must not clobber the user's edit.
+        assertEquals(LocalesWithText(mapOf("en" to "zero")), shadow.localizedUtterance)
+        assertEquals(1234L, shadow.lastSpokenDate)
     }
 
     private fun makePresetPhrases(): List<PresetPhrase> {

--- a/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
@@ -163,6 +163,61 @@ class RoomPresetPhrasesRepositoryTest {
         assertEquals(1234L, shadow.lastSpokenDate)
     }
 
+    @Test
+    fun given_a_shadow_stranded_by_a_preset_only_resync_populateDatabase_still_repairs_it() = runTest {
+        val database = createDatabase()
+        // The state a release that resynced only the preset rows leaves behind: the preset row
+        // already matches the array, so a shadow resync gated on the preset row being stale would
+        // never fire and these installs would stay broken forever.
+        database.presetPhrasesDao().insertPhrases(
+            listOf(
+                PresetPhraseDto(
+                    phraseId = "category_123_0",
+                    parentCategoryId = PresetCategories.USER_KEYPAD.id,
+                    creationDate = 0L,
+                    lastSpokenDate = null,
+                    sortOrder = 9,
+                )
+            )
+        )
+        database.presetPhrasesDao().deletePhrase("category_123_0", deleted = true)
+        database.phraseDao().insertPhrase(
+            PhraseDto(
+                phraseId = "category_123_0",
+                parentCategoryId = PresetCategories.USER_KEYPAD.id,
+                creationDate = 0L,
+                lastSpokenDate = null,
+                localizedUtterance = LocalesWithText(mapOf("en" to "zero")),
+                sortOrder = 0,
+            )
+        )
+
+        createRepository(database).populateDatabase()
+
+        assertEquals(9, database.phraseDao().getPhrase("category_123_0")!!.sortOrder)
+    }
+
+    @Test
+    fun populateDatabase_leaves_a_genuinely_custom_phrase_sort_order_alone() = runTest {
+        val database = createDatabase()
+        // Custom phrases get a UUID, so they can't collide with an array entry name - the resync
+        // must not touch the order the user arranged them in.
+        database.phraseDao().insertPhrase(
+            PhraseDto(
+                phraseId = "a-random-uuid",
+                parentCategoryId = PresetCategories.USER_KEYPAD.id,
+                creationDate = 0L,
+                lastSpokenDate = null,
+                localizedUtterance = LocalesWithText(mapOf("en" to "mine")),
+                sortOrder = 3,
+            )
+        )
+
+        createRepository(database).populateDatabase()
+
+        assertEquals(3, database.phraseDao().getPhrase("a-random-uuid")!!.sortOrder)
+    }
+
     private fun makePresetPhrases(): List<PresetPhrase> {
         return PresetCategories.values()
             .filterNot { it == PresetCategories.MY_SAYINGS || it == PresetCategories.RECENTS }

--- a/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/presets/RoomPresetPhrasesRepositoryTest.kt
@@ -7,6 +7,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.willowtree.vocable.domain.model.PresetCategories
 import com.willowtree.vocable.domain.model.PresetPhrase
 import com.willowtree.vocable.data.repository.RoomPresetPhrasesRepository
+import com.willowtree.vocable.data.room.PresetPhraseDto
+import com.willowtree.vocable.data.room.PresetPhrasesDao
 import com.willowtree.vocable.data.room.VocableDatabase
 import com.willowtree.vocable.utility.FakeDateProvider
 import com.willowtree.vocable.utility.VocableKoinTestRule
@@ -22,12 +24,16 @@ class RoomPresetPhrasesRepositoryTest {
     @get:Rule
     val vocableKoinTestRule = VocableKoinTestRule()
 
-    private fun createRepository(): RoomPresetPhrasesRepository {
+    private fun createDao(): PresetPhrasesDao = Room.inMemoryDatabaseBuilder(
+        ApplicationProvider.getApplicationContext(),
+        VocableDatabase::class.java
+    ).build().presetPhrasesDao()
+
+    private fun createRepository(
+        dao: PresetPhrasesDao = createDao()
+    ): RoomPresetPhrasesRepository {
         return RoomPresetPhrasesRepository(
-            presetPhrasesDao = Room.inMemoryDatabaseBuilder(
-                ApplicationProvider.getApplicationContext(),
-                VocableDatabase::class.java
-            ).build().presetPhrasesDao(),
+            presetPhrasesDao = dao,
             dateProvider = FakeDateProvider()
         )
     }
@@ -58,6 +64,60 @@ class RoomPresetPhrasesRepositoryTest {
         assertEquals(
             expectedPhrases,
             repository.getAllPresetPhrases()
+        )
+    }
+
+    @Test
+    fun given_a_phrase_seeded_with_a_stale_sort_order_populateDatabase_resyncs_it() = runTest {
+        val dao = createDao()
+        // A phrase seeded by an earlier release, before R.array.category_123 was reordered into
+        // phone-keypad order. Without a resync the array is only the source of truth on a fresh
+        // install and the reorder is invisible to anyone who already ran the app - see #611.
+        dao.insertPhrases(
+            listOf(
+                PresetPhraseDto(
+                    phraseId = "category_123_0",
+                    parentCategoryId = PresetCategories.USER_KEYPAD.id,
+                    creationDate = 0L,
+                    lastSpokenDate = 1234L,
+                    sortOrder = 0,
+                )
+            )
+        )
+
+        createRepository(dao).populateDatabase()
+
+        val keypadPhrase = dao.getPhrase("category_123_0")!!
+        assertEquals(9, keypadPhrase.sortOrder)
+        // The resync must not clobber unrelated columns.
+        assertEquals(1234L, keypadPhrase.lastSpokenDate)
+        assertEquals(false, keypadPhrase.deleted)
+    }
+
+    @Test
+    fun given_a_stale_phrase_populateDatabase_does_not_duplicate_or_misorder_the_category() = runTest {
+        val dao = createDao()
+        dao.insertPhrases(
+            listOf(
+                PresetPhraseDto(
+                    phraseId = "category_123_0",
+                    parentCategoryId = PresetCategories.USER_KEYPAD.id,
+                    creationDate = 0L,
+                    lastSpokenDate = null,
+                    sortOrder = 0,
+                )
+            )
+        )
+
+        val repository = createRepository(dao)
+        repository.populateDatabase()
+
+        // Newly inserted phrases take their array index too, so they can't collide with the
+        // sort order of a phrase that was already present.
+        assertEquals(
+            makePresetPhrases().filter { it.parentCategoryId == PresetCategories.USER_KEYPAD.id },
+            repository.getPhrasesForCategory(PresetCategories.USER_KEYPAD.id)
+                .sortedBy { it.sortOrder }
         )
     }
 

--- a/app/src/androidTest/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/settings/EditCategoriesViewModelTest.kt
@@ -43,6 +43,7 @@ class EditCategoriesViewModelTest {
     private val storedCategoriesRepository = RoomStoredCategoriesRepository(database)
     private val presetPhrasesRepository = RoomPresetPhrasesRepository(
         database.presetPhrasesDao(),
+        database.phraseDao(),
         FakeDateProvider()
     )
     private val storedPhrasesRepository = RoomStoredPhrasesRepository(database, FakeDateProvider())

--- a/app/src/main/java/com/willowtree/vocable/core/IVocableSharedPreferences.kt
+++ b/app/src/main/java/com/willowtree/vocable/core/IVocableSharedPreferences.kt
@@ -24,8 +24,4 @@ interface IVocableSharedPreferences {
     fun setHeadTrackingEnabled(enabled: Boolean)
 
     fun getHeadTrackingEnabled(): Boolean
-
-    fun setFirstTime()
-
-    fun getFirstTime(): Boolean
 }

--- a/app/src/main/java/com/willowtree/vocable/core/VocableSharedPreferences.kt
+++ b/app/src/main/java/com/willowtree/vocable/core/VocableSharedPreferences.kt
@@ -25,7 +25,6 @@ class VocableSharedPreferences :
         const val DEFAULT_SENSITIVITY = MEDIUM_SENSITIVITY
         const val KEY_DWELL_TIME = "KEY_DWELL_TIME"
         const val DEFAULT_DWELL_TIME = DWELL_TIME_ONE_SECOND
-        const val KEY_FIRST_TIME = "KEY_FIRST_TIME_OPENING"
     }
 
     private val encryptedPrefs: SharedPreferences by lazy {
@@ -80,13 +79,6 @@ class VocableSharedPreferences :
 
     override fun getHeadTrackingEnabled(): Boolean =
         encryptedPrefs.getBoolean(KEY_HEAD_TRACKING_ENABLED, true)
-
-    override fun setFirstTime() {
-        encryptedPrefs.edit { putBoolean(KEY_FIRST_TIME, false) }
-    }
-
-    override fun getFirstTime(): Boolean =
-        encryptedPrefs.getBoolean(KEY_FIRST_TIME, true)
 
     @SuppressLint("ApplySharedPref")
     fun clearAll() {

--- a/app/src/main/java/com/willowtree/vocable/data/repository/RoomPresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/RoomPresetPhrasesRepository.kt
@@ -81,6 +81,11 @@ class RoomPresetPhrasesRepository(
             val resources = get().get<Context>().resources
             val existingSortOrders = presetPhrasesDao.getAllPresetPhrases()
                 .associate { it.phraseId to it.sortOrder }
+            // Editing a preset soft-deletes its PresetPhrase row and stores a "shadow" phrase
+            // reusing the same id, so a stored row keyed by an array entry name is always a
+            // shadow - genuinely custom phrases get a UUID and can never collide here.
+            val shadowSortOrders = phraseDao.getAllPhrases()
+                .associate { it.phraseId to it.sortOrder }
 
             PresetCategories.values().forEach { presetCategory ->
                 if (presetCategory != PresetCategories.RECENTS && presetCategory != PresetCategories.MY_SAYINGS) {
@@ -105,10 +110,12 @@ class RoomPresetPhrasesRepository(
                             // seeded by an earlier release keeps whatever sort_order it was given
                             // then - resync it so reordering an array actually takes effect.
                             presetPhrasesDao.updatePhraseSortOrder(phraseEntryName, index)
-                            // Editing a preset leaves a stored "shadow" phrase behind that reuses
-                            // the preset's id and the sort_order captured at edit time. Renumber
-                            // it in step, or the two disagree and the category renders with a
-                            // duplicated sort order - and one phrase too many for its page.
+                        }
+                        // Checked independently of the preset row above: a release that resynced
+                        // only the preset rows leaves an install whose presets already match the
+                        // array while its shadows still carry the pre-reorder index, so keying
+                        // this off the preset row would strand exactly those installs.
+                        if (shadowSortOrders[phraseEntryName].let { it != null && it != index }) {
                             phraseDao.updatePhraseSortOrder(phraseEntryName, index)
                         }
                     }

--- a/app/src/main/java/com/willowtree/vocable/data/repository/RoomPresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/RoomPresetPhrasesRepository.kt
@@ -76,28 +76,33 @@ class RoomPresetPhrasesRepository(
 
     private suspend fun ensurePopulated() {
         phrasesMutex.withLock {
-            val existingPresetPhrases = presetPhrasesDao.getAllPresetPhrases()
-            val existingResourceIdStrings = existingPresetPhrases.map { it.phraseId }.toSet()
+            val resources = get().get<Context>().resources
+            val existingSortOrders = presetPhrasesDao.getAllPresetPhrases()
+                .associate { it.phraseId to it.sortOrder }
 
             PresetCategories.values().forEach { presetCategory ->
                 if (presetCategory != PresetCategories.RECENTS && presetCategory != PresetCategories.MY_SAYINGS) {
-                    val phrasesIds = get().get<Context>()
-                        .resources.obtainTypedArray(presetCategory.getArrayId())
+                    val phrasesIds = resources.obtainTypedArray(presetCategory.getArrayId())
                     val phraseObjects = mutableListOf<PresetPhraseDto>()
                     for (index in 0 until phrasesIds.length()) {
                         val phraseId = phrasesIds.getResourceId(index, 0)
-                        val phraseEntryName =
-                            get().get<Context>().resources.getResourceEntryName(phraseId)
-                        if (phraseEntryName !in existingResourceIdStrings) {
+                        val phraseEntryName = resources.getResourceEntryName(phraseId)
+                        val existingSortOrder = existingSortOrders[phraseEntryName]
+                        if (existingSortOrder == null) {
                             phraseObjects.add(
                                 PresetPhraseDto(
                                     phraseId = phraseEntryName,
                                     parentCategoryId = presetCategory.id,
                                     creationDate = System.currentTimeMillis(),
                                     lastSpokenDate = null,
-                                    sortOrder = phraseObjects.size,
+                                    sortOrder = index,
                                 )
                             )
+                        } else if (existingSortOrder != index) {
+                            // The array is the source of truth for display order, but a phrase
+                            // seeded by an earlier release keeps whatever sort_order it was given
+                            // then - resync it so reordering an array actually takes effect.
+                            presetPhrasesDao.updatePhraseSortOrder(phraseEntryName, index)
                         }
                     }
                     phrasesIds.recycle()

--- a/app/src/main/java/com/willowtree/vocable/data/repository/RoomPresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/RoomPresetPhrasesRepository.kt
@@ -1,6 +1,7 @@
 package com.willowtree.vocable.data.repository
 
 import android.content.Context
+import com.willowtree.vocable.data.room.PhraseDao
 import com.willowtree.vocable.data.room.PhraseSpokenDate
 import com.willowtree.vocable.data.room.PresetPhraseDto
 import com.willowtree.vocable.data.room.PresetPhrasesDao
@@ -17,6 +18,7 @@ import kotlin.collections.map
 
 class RoomPresetPhrasesRepository(
     private val presetPhrasesDao: PresetPhrasesDao,
+    private val phraseDao: PhraseDao,
     private val dateProvider: DateProvider,
 ) : PresetPhrasesRepository {
 
@@ -103,6 +105,11 @@ class RoomPresetPhrasesRepository(
                             // seeded by an earlier release keeps whatever sort_order it was given
                             // then - resync it so reordering an array actually takes effect.
                             presetPhrasesDao.updatePhraseSortOrder(phraseEntryName, index)
+                            // Editing a preset leaves a stored "shadow" phrase behind that reuses
+                            // the preset's id and the sort_order captured at edit time. Renumber
+                            // it in step, or the two disagree and the category renders with a
+                            // duplicated sort order - and one phrase too many for its page.
+                            phraseDao.updatePhraseSortOrder(phraseEntryName, index)
                         }
                     }
                     phrasesIds.recycle()

--- a/app/src/main/java/com/willowtree/vocable/data/room/PhraseDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/room/PhraseDao.kt
@@ -38,6 +38,9 @@ interface PhraseDao {
     @Query("SELECT * FROM Phrase WHERE phrase_id == :phraseId")
     suspend fun getPhrase(phraseId: String): PhraseDto?
 
+    @Query("SELECT * FROM Phrase")
+    suspend fun getAllPhrases(): List<PhraseDto>
+
     /**
      * Targeted update rather than an insert with [OnConflictStrategy.REPLACE], which would
      * clobber the row's localized_utterance and last_spoken_date. A no-op when no row with

--- a/app/src/main/java/com/willowtree/vocable/data/room/PhraseDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/room/PhraseDao.kt
@@ -37,4 +37,12 @@ interface PhraseDao {
 
     @Query("SELECT * FROM Phrase WHERE phrase_id == :phraseId")
     suspend fun getPhrase(phraseId: String): PhraseDto?
+
+    /**
+     * Targeted update rather than an insert with [OnConflictStrategy.REPLACE], which would
+     * clobber the row's localized_utterance and last_spoken_date. A no-op when no row with
+     * this id is stored.
+     */
+    @Query("UPDATE Phrase SET sort_order = :sortOrder WHERE phrase_id = :phraseId")
+    suspend fun updatePhraseSortOrder(phraseId: String, sortOrder: Int)
 }

--- a/app/src/main/java/com/willowtree/vocable/data/room/PresetPhrasesDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/room/PresetPhrasesDao.kt
@@ -36,4 +36,11 @@ interface PresetPhrasesDao {
 
     @Query("UPDATE PresetPhrase SET deleted = :deleted WHERE phrase_id = :phraseId")
     suspend fun deletePhrase(phraseId: String, deleted: Boolean)
+
+    /**
+     * Targeted update rather than an insert with [OnConflictStrategy.REPLACE], which would
+     * clobber the row's last_spoken_date and deleted flag.
+     */
+    @Query("UPDATE PresetPhrase SET sort_order = :sortOrder WHERE phrase_id = :phraseId")
+    suspend fun updatePhraseSortOrder(phraseId: String, sortOrder: Int)
 }

--- a/app/src/main/java/com/willowtree/vocable/di/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/di/AppKoinModule.kt
@@ -60,7 +60,7 @@ import org.koin.dsl.module
 val vocableKoinModule = module {
 
     scope<SplashActivity> {
-        viewModel { SplashViewModel(get(), get(), get(named<SplashViewModel>())) }
+        viewModel { SplashViewModel(get(), get(named<SplashViewModel>())) }
     }
 
     scope<MainActivity> {

--- a/app/src/main/java/com/willowtree/vocable/di/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/di/AppKoinModule.kt
@@ -106,9 +106,10 @@ val vocableKoinModule = module {
     single { RoomStoredCategoriesRepository(get()) } bind StoredCategoriesRepository::class
     single { RoomPresetCategoriesRepository(get()) } bind PresetCategoriesRepository::class
     single { RoomStoredPhrasesRepository(get(), get()) } bind StoredPhrasesRepository::class
-    single { RoomPresetPhrasesRepository(get(), get()) } bind PresetPhrasesRepository::class
+    single { RoomPresetPhrasesRepository(get(), get(), get()) } bind PresetPhrasesRepository::class
     single { VocableDatabase.createVocableDatabase(get()) }
     single { get<VocableDatabase>().presetPhrasesDao() }
+    single { get<VocableDatabase>().phraseDao() }
     single<VocableEnvironment> { VocableEnvironmentImpl() }
 
     viewModel { PresetsViewModel(get(), get(), get(named<PresetsViewModel>()), get()) }

--- a/app/src/main/java/com/willowtree/vocable/domain/usecase/PhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/domain/usecase/PhrasesUseCase.kt
@@ -38,7 +38,10 @@ class PhrasesUseCase(
                     .sortedByDescending { it.lastSpokenDate }
                     .take(8)
             } else {
-                stored + presets
+                // sort_order is the display order every category screen shows - the DAO queries
+                // return insertion order, which only matches on a fresh install. Sorting here
+                // keeps the Presets grid and Edit Phrases list in agreement.
+                (stored + presets).sortedBy { it.sortOrder }
             }
         }
     }

--- a/app/src/main/java/com/willowtree/vocable/ui/presets/PresetsScreen.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/presets/PresetsScreen.kt
@@ -679,19 +679,18 @@ fun PresetsScreenPreview2() {
             ),
             selectedCategory = Category.PresetCategory(PresetCategories.USER_KEYPAD.id, 0, false),
             currentPhrases = listOf(
-                PhraseGridItem.Phrase("1", "0"),
-                PhraseGridItem.Phrase("2", "1"),
-                PhraseGridItem.Phrase("3", "2"),
-                PhraseGridItem.Phrase("4", "3"),
-                PhraseGridItem.Phrase("5", "4"),
-                PhraseGridItem.Phrase("6", "5"),
-                PhraseGridItem.Phrase("7", "6"),
-                PhraseGridItem.Phrase("5", "7"),
-                PhraseGridItem.Phrase("6", "8"),
-                PhraseGridItem.Phrase("7", "9"),
-                PhraseGridItem.Phrase("8", "Yes"),
-                PhraseGridItem.Phrase("9", "No"),
-                PhraseGridItem.AddPhrase
+                PhraseGridItem.Phrase("1", "1"),
+                PhraseGridItem.Phrase("2", "2"),
+                PhraseGridItem.Phrase("3", "3"),
+                PhraseGridItem.Phrase("4", "4"),
+                PhraseGridItem.Phrase("5", "5"),
+                PhraseGridItem.Phrase("6", "6"),
+                PhraseGridItem.Phrase("7", "7"),
+                PhraseGridItem.Phrase("8", "8"),
+                PhraseGridItem.Phrase("9", "9"),
+                PhraseGridItem.Phrase("10", "0"),
+                PhraseGridItem.Phrase("11", "No"),
+                PhraseGridItem.Phrase("12", "Yes")
             ),
             isLoadingPhrases = false,
             onCategorySelected = {},
@@ -700,7 +699,7 @@ fun PresetsScreenPreview2() {
             onNavigateToSettings = {},
             onPhraseClick = { _, _ -> },
             isSpeaking = true,
-            activeText = "0"
+            activeText = "1"
         )
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/ui/presets/PresetsScreen.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/presets/PresetsScreen.kt
@@ -117,7 +117,11 @@ private fun PresetsContent(
             integerResource(id = R.integer.phrases_columns_one_liner_phrases)
         } else integerResource(id = R.integer.phrases_columns)
     }
-    val phraseRows = integerResource(id = R.integer.phrases_rows)
+    val phraseRows = selectedCategory?.categoryId.let { id ->
+        if (id == PresetCategories.USER_KEYPAD.id) {
+            integerResource(id = R.integer.phrases_rows_one_liner_phrases)
+        } else integerResource(id = R.integer.phrases_rows)
+    }
     val maxCategories = integerResource(id = R.integer.max_categories)
     val maxPhrases = selectedCategory?.categoryId.let { id ->
         if (id == PresetCategories.USER_KEYPAD.id) {
@@ -653,6 +657,16 @@ fun PresetsScreenPreview() {
 @Preview(
     name = "Landscape",
     device = "spec:width=800dp,height=400dp,dpi=240",
+    showBackground = true,
+)
+@Preview(
+    name = "Tablet Portrait",
+    device = "spec:width=800dp,height=1280dp,dpi=240",
+    showBackground = true,
+)
+@Preview(
+    name = "Tablet Landscape",
+    device = "spec:width=1280dp,height=800dp,dpi=240",
     showBackground = true,
 )
 @Composable

--- a/app/src/main/java/com/willowtree/vocable/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/splash/SplashViewModel.kt
@@ -6,12 +6,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.willowtree.vocable.data.repository.RoomPresetPhrasesRepository
 import com.willowtree.vocable.core.IdlingResourceContainer
-import com.willowtree.vocable.core.VocableSharedPreferences
 import kotlinx.coroutines.launch
 
 class SplashViewModel(
     private val newPresetsRepository: RoomPresetPhrasesRepository,
-    private val sharedPrefs: VocableSharedPreferences,
     private val idlingResourceContainer: IdlingResourceContainer
 ) : ViewModel() {
 
@@ -25,10 +23,11 @@ class SplashViewModel(
     private fun populateDatabase() {
         viewModelScope.launch {
             idlingResourceContainer.run {
-                if (sharedPrefs.getFirstTime()) {
-                    newPresetsRepository.populateDatabase()
-                    sharedPrefs.setFirstTime()
-                }
+                // Runs on every launch, not just the first: seeding is idempotent, and it is also
+                // what reconciles the stored preset phrases with the resource arrays. Gating it on
+                // a first-time flag meant a phrase added to - or reordered within - an array in a
+                // later release never reached anyone who had already opened the app.
+                newPresetsRepository.populateDatabase()
 
                 liveExitSplash.postValue(true)
             }

--- a/app/src/main/res/values-land/integers.xml
+++ b/app/src/main/res/values-land/integers.xml
@@ -7,6 +7,7 @@
     <integer name="phrases_columns">3</integer>
     <integer name="phrases_columns_one_liner_phrases">6</integer>
     <integer name="phrases_rows">2</integer>
+    <integer name="phrases_rows_one_liner_phrases">2</integer>
     <integer name="settings_options_rows">3</integer>
     <integer name="settings_options_columns">2</integer>
     <integer name="edit_keyboard_columns">10</integer>

--- a/app/src/main/res/values-sw400dp-land/integers.xml
+++ b/app/src/main/res/values-sw400dp-land/integers.xml
@@ -7,6 +7,7 @@
     <integer name="phrases_columns">3</integer>
     <integer name="phrases_columns_one_liner_phrases">6</integer>
     <integer name="phrases_rows">2</integer>
+    <integer name="phrases_rows_one_liner_phrases">2</integer>
     <integer name="settings_options_rows">3</integer>
     <integer name="settings_options_columns">2</integer>
     <integer name="edit_keyboard_columns">10</integer>

--- a/app/src/main/res/values-sw400dp/integers.xml
+++ b/app/src/main/res/values-sw400dp/integers.xml
@@ -7,6 +7,7 @@
     <integer name="phrases_columns">2</integer>
     <integer name="phrases_columns_one_liner_phrases">3</integer>
     <integer name="phrases_rows">4</integer>
+    <integer name="phrases_rows_one_liner_phrases">4</integer>
     <integer name="edit_phrases_columns">1</integer>
     <integer name="edit_phrases_rows">4</integer>
     <integer name="settings_options_rows">5</integer>

--- a/app/src/main/res/values-sw600dp-land/integers.xml
+++ b/app/src/main/res/values-sw600dp-land/integers.xml
@@ -5,8 +5,9 @@
     <integer name="max_phrases_one_liner">12</integer>
     <integer name="max_edit_phrases">6</integer>
     <integer name="phrases_columns">3</integer>
-    <integer name="phrases_columns_one_liner_phrases">6</integer>
+    <integer name="phrases_columns_one_liner_phrases">3</integer>
     <integer name="phrases_rows">3</integer>
+    <integer name="phrases_rows_one_liner_phrases">4</integer>
     <integer name="edit_phrases_columns">2</integer>
     <integer name="edit_phrases_rows">3</integer>
     <integer name="selection_modes_rows">2</integer>

--- a/app/src/main/res/values-sw600dp/integers.xml
+++ b/app/src/main/res/values-sw600dp/integers.xml
@@ -7,6 +7,7 @@
     <integer name="phrases_columns">2</integer>
     <integer name="phrases_columns_one_liner_phrases">3</integer>
     <integer name="phrases_rows">5</integer>
+    <integer name="phrases_rows_one_liner_phrases">4</integer>
     <integer name="settings_options_rows">3</integer>
     <integer name="settings_options_columns">2</integer>
     <integer name="edit_keyboard_columns">10</integer>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -46,6 +46,10 @@
         1 2 3 / 4 5 6 / 7 8 9 / 0 No Yes at the 3-column breakpoints and
         1 2 3 4 5 6 / 7 8 9 0 No Yes at the 6-column ones. Both match the approved designs.
         Order is authoritative - PresetPhrase.sort_order is synced from these indices on launch.
+        Additions and reorders are handled; removing an item or moving it to another array is not,
+        because the resync never deletes or re-parents an existing row. An install upgraded past
+        such a change keeps the orphan row, which then collides with whatever entry took its index.
+        See RoomPresetPhrasesRepository.ensurePopulated.
     -->
     <string-array name="category_123">
         <item>@string/category_123_1</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -41,8 +41,13 @@
         <item>@string/settings_reset_app</item>
     </string-array>
 
+    <!--
+        Phone-keypad order: the grid fills row-major, so this flat sequence renders as
+        1 2 3 / 4 5 6 / 7 8 9 / 0 No Yes at the 3-column breakpoints and
+        1 2 3 4 5 6 / 7 8 9 0 No Yes at the 6-column ones. Both match the approved designs.
+        Order is authoritative - PresetPhrase.sort_order is synced from these indices on launch.
+    -->
     <string-array name="category_123">
-        <item>@string/category_123_0</item>
         <item>@string/category_123_1</item>
         <item>@string/category_123_2</item>
         <item>@string/category_123_3</item>
@@ -52,8 +57,9 @@
         <item>@string/category_123_7</item>
         <item>@string/category_123_8</item>
         <item>@string/category_123_9</item>
-        <item>@string/category_123_yes</item>
+        <item>@string/category_123_0</item>
         <item>@string/category_123_no</item>
+        <item>@string/category_123_yes</item>
     </string-array>
 
     <array name="category_basic_needs">

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -7,6 +7,7 @@
     <integer name="phrases_columns_one_liner_phrases">3</integer>
     <integer name="phrases_columns">2</integer>
     <integer name="phrases_rows">4</integer>
+    <integer name="phrases_rows_one_liner_phrases">4</integer>
     <integer name="edit_phrases_columns">1</integer>
     <integer name="edit_phrases_rows">4</integer>
     <integer name="settings_options_rows">5</integer>

--- a/app/src/test/java/com/willowtree/vocable/presets/KeypadPhraseOrderTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/KeypadPhraseOrderTest.kt
@@ -40,18 +40,52 @@ class KeypadPhraseOrderTest {
         )
     }
 
+    /**
+     * The layouts signed off in the designs, keyed by column count. A breakpoint that uses any
+     * other column count has no approved keypad shape, so it has to be added here deliberately
+     * rather than passing by accident - 4 columns, for instance, still satisfies
+     * columns x rows == max_phrases_one_liner while rendering 1 2 3 4 / 5 6 7 8 / 9 0 No Yes.
+     */
+    private val approvedLayouts = mapOf(
+        3 to listOf(
+            listOf("category_123_1", "category_123_2", "category_123_3"),
+            listOf("category_123_4", "category_123_5", "category_123_6"),
+            listOf("category_123_7", "category_123_8", "category_123_9"),
+            listOf("category_123_0", "category_123_no", "category_123_yes")
+        ),
+        6 to listOf(
+            listOf(
+                "category_123_1", "category_123_2", "category_123_3",
+                "category_123_4", "category_123_5", "category_123_6"
+            ),
+            listOf(
+                "category_123_7", "category_123_8", "category_123_9",
+                "category_123_0", "category_123_no", "category_123_yes"
+            )
+        )
+    )
+
     @Test
-    fun `zero no and yes fill the bottom row at every breakpoint`() {
+    fun `every breakpoint renders an approved keypad layout`() {
         ResourceXml.breakpointDirs.forEach { dir ->
             val integers = ResourceXml.integers(dir)
             val columns = integers.getValue("phrases_columns_one_liner_phrases")
             val rows = integers.getValue("phrases_rows_one_liner_phrases")
 
-            val bottomRow = keypadOrder.drop((rows - 1) * columns)
+            val expected = approvedLayouts[columns]
+                ?: throw AssertionError(
+                    "$dir/integers.xml: $columns columns has no approved keypad layout - add one " +
+                        "to approvedLayouts once the design is signed off"
+                )
             assertEquals(
-                "$dir/integers.xml: with $columns columns the keypad's bottom row should end in 0, No, Yes but was $bottomRow",
-                listOf("category_123_0", "category_123_no", "category_123_yes"),
-                bottomRow.takeLast(3)
+                "$dir/integers.xml: a $columns-column keypad needs ${expected.size} rows",
+                expected.size,
+                rows
+            )
+            assertEquals(
+                "$dir/integers.xml: $columns columns x $rows rows does not render the keypad",
+                expected,
+                keypadOrder.chunked(columns)
             )
         }
     }

--- a/app/src/test/java/com/willowtree/vocable/presets/KeypadPhraseOrderTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/KeypadPhraseOrderTest.kt
@@ -1,0 +1,58 @@
+package com.willowtree.vocable.presets
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The "123" category is laid out row-major by PresetsScreen, so the declaration order of
+ * R.array.category_123 is what produces the phone-keypad shape the designs call for:
+ *
+ *     3 columns          6 columns
+ *     1 2 3              1 2 3 4 5 6
+ *     4 5 6              7 8 9 0 No Yes
+ *     7 8 9
+ *     0 No Yes
+ *
+ * Order is also what seeds PresetPhrase.sort_order, so a reorder here changes what users see.
+ */
+class KeypadPhraseOrderTest {
+
+    private val keypadOrder = listOf(
+        "category_123_1",
+        "category_123_2",
+        "category_123_3",
+        "category_123_4",
+        "category_123_5",
+        "category_123_6",
+        "category_123_7",
+        "category_123_8",
+        "category_123_9",
+        "category_123_0",
+        "category_123_no",
+        "category_123_yes"
+    )
+
+    @Test
+    fun `keypad phrases are declared in phone-keypad order`() {
+        assertEquals(
+            keypadOrder,
+            ResourceXml.stringArrayEntryNames("values", "category_123")
+        )
+    }
+
+    @Test
+    fun `zero no and yes fill the bottom row at every breakpoint`() {
+        ResourceXml.breakpointDirs.forEach { dir ->
+            val integers = ResourceXml.integers(dir)
+            val columns = integers.getValue("phrases_columns_one_liner_phrases")
+            val rows = integers.getValue("phrases_rows_one_liner_phrases")
+
+            val bottomRow = keypadOrder.drop((rows - 1) * columns)
+            assertEquals(
+                "$dir/integers.xml: with $columns columns the keypad's bottom row should end in 0, No, Yes but was $bottomRow",
+                listOf("category_123_0", "category_123_no", "category_123_yes"),
+                bottomRow.takeLast(3)
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/willowtree/vocable/presets/PhraseGridResourceInvariantTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PhraseGridResourceInvariantTest.kt
@@ -2,9 +2,6 @@ package com.willowtree.vocable.presets
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.w3c.dom.Element
-import java.io.File
-import javax.xml.parsers.DocumentBuilderFactory
 
 /**
  * The phrases grid renders a fixed [rows] x [columns] matrix and pages through items
@@ -14,29 +11,10 @@ import javax.xml.parsers.DocumentBuilderFactory
  */
 class PhraseGridResourceInvariantTest {
 
-    private val breakpointDirs = listOf(
-        "values",
-        "values-land",
-        "values-sw400dp",
-        "values-sw400dp-land",
-        "values-sw600dp",
-        "values-sw600dp-land"
-    )
-
-    private fun readIntegers(dir: String): Map<String, Int> {
-        val file = File("src/main/res/$dir/integers.xml")
-        val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file)
-        val nodes = document.getElementsByTagName("integer")
-        return (0 until nodes.length).associate { i ->
-            val element = nodes.item(i) as Element
-            element.getAttribute("name") to element.textContent.trim().toInt()
-        }
-    }
-
     @Test
     fun `generic phrase grid dimensions equal max phrases for every breakpoint`() {
-        breakpointDirs.forEach { dir ->
-            val integers = readIntegers(dir)
+        ResourceXml.breakpointDirs.forEach { dir ->
+            val integers = ResourceXml.integers(dir)
             val columns = integers.getValue("phrases_columns")
             val rows = integers.getValue("phrases_rows")
             val maxPhrases = integers.getValue("max_phrases")
@@ -50,8 +28,8 @@ class PhraseGridResourceInvariantTest {
 
     @Test
     fun `keypad one-liner phrase grid dimensions equal max phrases for every breakpoint`() {
-        breakpointDirs.forEach { dir ->
-            val integers = readIntegers(dir)
+        ResourceXml.breakpointDirs.forEach { dir ->
+            val integers = ResourceXml.integers(dir)
             val columns = integers.getValue("phrases_columns_one_liner_phrases")
             val rows = integers.getValue("phrases_rows_one_liner_phrases")
             val maxPhrases = integers.getValue("max_phrases_one_liner")

--- a/app/src/test/java/com/willowtree/vocable/presets/PhraseGridResourceInvariantTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/PhraseGridResourceInvariantTest.kt
@@ -1,0 +1,65 @@
+package com.willowtree.vocable.presets
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * The phrases grid renders a fixed [rows] x [columns] matrix and pages through items
+ * [maxPhrases] at a time. If rows x columns != maxPhrases for any breakpoint, the grid
+ * either shows a blank row/column (too many cells) or silently drops phrases that can
+ * never be paged into view (too few cells) - see #611.
+ */
+class PhraseGridResourceInvariantTest {
+
+    private val breakpointDirs = listOf(
+        "values",
+        "values-land",
+        "values-sw400dp",
+        "values-sw400dp-land",
+        "values-sw600dp",
+        "values-sw600dp-land"
+    )
+
+    private fun readIntegers(dir: String): Map<String, Int> {
+        val file = File("src/main/res/$dir/integers.xml")
+        val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file)
+        val nodes = document.getElementsByTagName("integer")
+        return (0 until nodes.length).associate { i ->
+            val element = nodes.item(i) as Element
+            element.getAttribute("name") to element.textContent.trim().toInt()
+        }
+    }
+
+    @Test
+    fun `generic phrase grid dimensions equal max phrases for every breakpoint`() {
+        breakpointDirs.forEach { dir ->
+            val integers = readIntegers(dir)
+            val columns = integers.getValue("phrases_columns")
+            val rows = integers.getValue("phrases_rows")
+            val maxPhrases = integers.getValue("max_phrases")
+            assertEquals(
+                "$dir/integers.xml: phrases_columns ($columns) x phrases_rows ($rows) should equal max_phrases ($maxPhrases)",
+                maxPhrases,
+                columns * rows
+            )
+        }
+    }
+
+    @Test
+    fun `keypad one-liner phrase grid dimensions equal max phrases for every breakpoint`() {
+        breakpointDirs.forEach { dir ->
+            val integers = readIntegers(dir)
+            val columns = integers.getValue("phrases_columns_one_liner_phrases")
+            val rows = integers.getValue("phrases_rows_one_liner_phrases")
+            val maxPhrases = integers.getValue("max_phrases_one_liner")
+            assertEquals(
+                "$dir/integers.xml: phrases_columns_one_liner_phrases ($columns) x phrases_rows_one_liner_phrases ($rows) should equal max_phrases_one_liner ($maxPhrases)",
+                maxPhrases,
+                columns * rows
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/willowtree/vocable/presets/ResourceXml.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/ResourceXml.kt
@@ -1,0 +1,49 @@
+package com.willowtree.vocable.presets
+
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Reads res/ XML directly off disk so these stay plain JVM tests - no Robolectric or device
+ * needed just to assert on values the resource compiler would otherwise hide behind R ids.
+ */
+internal object ResourceXml {
+
+    /** Every breakpoint that defines its own phrase grid dimensions. */
+    val breakpointDirs = listOf(
+        "values",
+        "values-land",
+        "values-sw400dp",
+        "values-sw400dp-land",
+        "values-sw600dp",
+        "values-sw600dp-land"
+    )
+
+    fun integers(dir: String): Map<String, Int> {
+        val nodes = parse(dir, "integers.xml").getElementsByTagName("integer")
+        return (0 until nodes.length).associate { i ->
+            val element = nodes.item(i) as Element
+            element.getAttribute("name") to element.textContent.trim().toInt()
+        }
+    }
+
+    /**
+     * Returns the resource entry names referenced by a string-array, in declaration order -
+     * e.g. `@string/category_123_1` becomes `category_123_1`.
+     */
+    fun stringArrayEntryNames(dir: String, arrayName: String): List<String> {
+        val arrays = parse(dir, "arrays.xml").getElementsByTagName("string-array")
+        val array = (0 until arrays.length)
+            .map { arrays.item(it) as Element }
+            .single { it.getAttribute("name") == arrayName }
+        val items = array.getElementsByTagName("item")
+        return (0 until items.length).map { i ->
+            items.item(i).textContent.trim().removePrefix("@string/")
+        }
+    }
+
+    private fun parse(dir: String, fileName: String) =
+        DocumentBuilderFactory.newInstance().newDocumentBuilder()
+            .parse(File("src/main/res/$dir/$fileName"))
+}

--- a/app/src/test/java/com/willowtree/vocable/presets/ResourceXml.kt
+++ b/app/src/test/java/com/willowtree/vocable/presets/ResourceXml.kt
@@ -10,15 +10,22 @@ import javax.xml.parsers.DocumentBuilderFactory
  */
 internal object ResourceXml {
 
-    /** Every breakpoint that defines its own phrase grid dimensions. */
-    val breakpointDirs = listOf(
-        "values",
-        "values-land",
-        "values-sw400dp",
-        "values-sw400dp-land",
-        "values-sw600dp",
-        "values-sw600dp-land"
-    )
+    /**
+     * Every breakpoint that defines its own phrase grid dimensions, discovered from disk so a
+     * newly added `values-*` dir is covered by the invariants without touching this file.
+     */
+    val breakpointDirs: List<String> by lazy {
+        File("src/main/res")
+            .listFiles { file: File -> file.isDirectory && file.name.startsWith("values") }
+            .orEmpty()
+            .filter { dir ->
+                File(dir, "integers.xml").exists() &&
+                    integers(dir.name).containsKey("phrases_columns")
+            }
+            .map { it.name }
+            .sorted()
+            .also { require(it.isNotEmpty()) { "No values*/integers.xml declared phrases_columns" } }
+    }
 
     fun integers(dir: String): Map<String, Int> {
         val nodes = parse(dir, "integers.xml").getElementsByTagName("integer")

--- a/app/src/test/java/com/willowtree/vocable/utils/FakeVocableSharedPreferences.kt
+++ b/app/src/test/java/com/willowtree/vocable/utils/FakeVocableSharedPreferences.kt
@@ -8,8 +8,7 @@ class FakeVocableSharedPreferences(
     private var mySayings: List<String> = listOf(),
     private var dwellTime: Long = 0,
     private var sensitivity: Float = 0f,
-    private var headTrackingEnabled: Boolean = false,
-    private var firstTime: Boolean = false
+    private var headTrackingEnabled: Boolean = false
 ) : IVocableSharedPreferences {
 
     override fun registerOnSharedPreferenceChangeListener(vararg listeners: SharedPreferences.OnSharedPreferenceChangeListener) {
@@ -50,13 +49,5 @@ class FakeVocableSharedPreferences(
 
     override fun getHeadTrackingEnabled(): Boolean {
         return headTrackingEnabled
-    }
-
-    override fun setFirstTime() {
-        firstTime = true
-    }
-
-    override fun getFirstTime(): Boolean {
-        return firstTime
     }
 }


### PR DESCRIPTION
## Summary

The "123" (Numbers) category rendered as a 6×3 / 3×5 grid with a blank row instead of the 3×4 keypad the designs call for. Fixing the grid shape exposed two further problems behind it: the item order wasn't a keypad either, and the mechanism that seeds preset phrases could never deliver a correction to anyone who had already opened the app.

### Grid shape

- `phraseRows` in `PresetsScreen.kt` had no `USER_KEYPAD` override (unlike `phraseColumns`), so it always fell back to the generic per-breakpoint row count. Added `phrases_rows_one_liner_phrases` to every breakpoint `integers.xml` and branched `phraseRows` on `USER_KEYPAD.id` the same way `phraseColumns` already does.
- Fixed `phrases_columns_one_liner_phrases` in `values-sw600dp-land/integers.xml` (was `6`, needs `3` for the 3×4 target).
- Handset values are unchanged — the new resource values match the generic ones there.
- Added tablet-width `@Preview` specs to `PresetsScreenPreview2` and corrected that preview's phrase list, which had duplicate ids and stale labels.

### Item order

`R.array.category_123` was declared `0 1 2 … 9 Yes No`. The grid fills row-major, so that renders `0 1 2 / 3 4 5 / …`, not a phone keypad. Reordered to `1 … 9 0 No Yes`, which renders `1 2 3 / 4 5 6 / 7 8 9 / 0 No Yes` at the 3-column breakpoints and `1 2 3 4 5 6 / 7 8 9 0 No Yes` at the 6-column ones — both matching the approved designs (Figma 64:2146 / 64:2175).

### Making the arrays authoritative

Reordering an array on its own changes nothing for an existing install, because `sort_order` is only written when a phrase is first seeded:

- `populateDatabase()` was gated behind a `firstTime` shared pref, so it never ran again after the first launch. Removed the gate — seeding is idempotent (`getAllPresetPhrases()` includes soft-deleted rows, so a user-deleted preset is not resurrected), and this is also what reconciles stored phrases against the arrays. A phrase *added* to an array in a past release never reached existing users either; that's fixed by the same change.
- `ensurePopulated()` now resyncs `sort_order` from the array index for rows that already exist.
- Editing a preset soft-deletes its `PresetPhrase` row and stores a "shadow" `Phrase` under the same id, so shadows carry their own `sort_order` and are resynced independently of the preset row — otherwise an install that had already resynced its preset rows would strand its shadows at the pre-reorder index.
- `getPhrasesForCategoryFlow` now sorts by `sortOrder`. Neither DAO query has an `ORDER BY`; `PresetsViewModel` sorted on its way to the grid but `EditCategoryPhrasesState` did not, so after a resync the Presets grid and the Edit Phrases list disagreed on order.

Known limitation, documented in `arrays.xml`: the resync handles additions and reorders, not removals or moves between arrays, since it never deletes or re-parents an existing row.

### Tests

- `PhraseGridResourceInvariantTest` — asserts `columns × rows == max_phrases` for both grids at every breakpoint, which is the invariant #611 violated.
- `KeypadPhraseOrderTest` — pins the array declaration order and asserts the full rendered row matrix against the signed-off layouts, so a column count with no approved layout fails loudly.
- Both discover breakpoint dirs from disk rather than a hardcoded list, so a new `values-*` dir is covered automatically.
- `RoomPresetPhrasesRepositoryTest` — covers reseeding, the `sort_order` resync, shadow resync, and that soft-deleted presets stay deleted across launches.

Closes #611.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — 40 tests, all passing
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` compiles
- [x] Tablet portrait/landscape Compose previews render 3×4 with no blank row
- [ ] `./gradlew connectedDebugAndroidTest` on a device/emulator (not run locally — no AVD available)
- [ ] Tablet AVD (`sw600dp`+), portrait + landscape: "123" renders the 3×4 keypad
- [ ] Handset portrait/landscape: "123" renders 3×4 / 6×2, other categories unchanged
- [ ] **Upgrade path** — install a pre-change build, open it, then install this build: "123" shows keypad order in both the Presets grid and Settings → Edit Categories → 123
- [ ] Edit a "123" phrase (creating a shadow), then relaunch: the edited phrase keeps its keypad position
- [ ] Delete a preset phrase, then relaunch: it stays deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
