### PR TITLE
ci: inject google-services.json in pre-release-upload (fixes #608)

### DIFF
--- a/.github/workflows/pre-release-upload.yml
+++ b/.github/workflows/pre-release-upload.yml
@@ -27,6 +27,11 @@ jobs:
           ENCODED_RELEASE_KEYSTORE: ${{ secrets.ENCODED_RELEASE_KEYSTORE }}
         run: echo $ENCODED_RELEASE_KEYSTORE | base64 -d > keystore
 
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
+        run: echo $GOOGLE_SERVICES_JSON_B64 | base64 -d > app/google-services.json
+
       - name: Build & Assemble Release APK
         env:
           VERSION_CODE: ${{ github.run_number }}


### PR DESCRIPTION
Fixes the pre-release-upload build failure: `assembleRelease` was erroring with `File google-services.json is missing` because `pre-release-upload.yml` lacked the google-services.json decode step that `ps-release.yml` already has (the plugin needs `app/google-services.json` at build time, and it's gitignored).

Surfaced only now: the pre-release-upload job had been skipped for months because `device-tests` always failed on the stale Firebase key; rotating the key (7/31) let it run and exposed this pre-existing gap.

Adds a **Decode google-services.json** step (env-var form, mirroring ps-release.yml so the secret stays out of logs) before `assembleRelease`. Closes #608.