### PR TITLE
Fix stale-voice detection to check download status, not just name/locale

### DIFF
--- a/Documentation/work-log/642-stale-voice-download-check.md
+++ b/Documentation/work-log/642-stale-voice-download-check.md
@@ -1,0 +1,23 @@
+# Stale-voice detection must check download status, not just name/locale match
+
+**Issue:** #642 (Part of #613, follow-up to #632/PR #633)
+
+## What was needed
+
+#632/#633 added live device-voice fallback and stale-voice recovery to `VocableTextToSpeech`, but its explicit-match check (`applySelectedVoice()`) only verified a selected voice's name, locale, and network-required flag — it never checked whether the voice's data was actually downloaded. Android's TTS engine keeps a voice listed in `TextToSpeech.getVoices()` even after its data is uninstalled; it's only flagged via `TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED`, not removed from the list. So a voice a user had explicitly picked, which later got uninstalled (the literal scenario #619 describes — "removed after an OS/engine update"), would still "match" by name and keep being treated as valid.
+
+## What changed
+
+- Added `isVoiceDownloaded()` (two overloads: one operating on a real `Voice`, one on the raw `features: Set<String>?` for testability) checking `KEY_FEATURE_NOT_INSTALLED`
+- `applySelectedVoice()`'s `availableVoiceNames` computation now requires both `isVoiceSupportedForLocale()` and `isVoiceDownloaded()` — a voice whose data was uninstalled no longer counts as "available," so `resolveVoiceSelection()` correctly returns `STALE_FALLBACK_TO_LIVE_DEFAULT` for it instead of `EXPLICIT`
+- `getAvailableVoices()` refactored to reuse the same helper instead of inlining the same check twice
+- 3 new unit tests on the pure `isVoiceDownloaded(features: Set<String>?)` overload
+
+## How this was found and verified
+
+Found via real on-device reproduction (not just code review) on a Google Play emulator image: selected a downloaded voice in Vocable's picker, uninstalled its data through the OS's own TTS voice manager (Settings → Accessibility → Text-to-speech → Install voice data → [language] → delete), then returned to the app — before the fix, it kept logging `applied voice: <name>` (the explicit-match branch) with no stale warning. After the fix, the same repro correctly logs the "no longer resolves" warning and falls back to `applied device default voice: ...`, and the persisted preference visibly clears back to "Default" in Selection Mode — confirmed both immediately (no relaunch needed, since it's evaluated live on the next `speak()` call) and after a full app relaunch.
+
+## Pointers
+
+- Issue: #642 · Parent: #613 · Follow-up to: #632 / PR #633
+- Related: #619 (this fixes a real gap in that ticket's stale-detection scope)

--- a/app/src/main/java/com/willowtree/vocable/core/VocableTextToSpeech.kt
+++ b/app/src/main/java/com/willowtree/vocable/core/VocableTextToSpeech.kt
@@ -84,12 +84,11 @@ object VocableTextToSpeech {
             }
             .sortedWith(compareByDescending<Voice> { it.quality }.thenBy { it.name })
             .map { voice ->
-                val isDownloaded = voice.features?.contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED) != true
                 VoiceOption(
                     name = voice.name,
                     displayName = buildVoiceDisplayName(voice),
                     locale = voice.locale,
-                    isDownloaded = isDownloaded
+                    isDownloaded = isVoiceDownloaded(voice)
                 )
             }
     }
@@ -159,7 +158,7 @@ object VocableTextToSpeech {
      */
     private fun applySelectedVoice(tts: TextToSpeech, selectedVoiceName: String?, locale: Locale): Boolean {
         val availableVoiceNames = tts.voices
-            ?.filter { isVoiceSupportedForLocale(tts, it, locale) }
+            ?.filter { isVoiceSupportedForLocale(tts, it, locale) && isVoiceDownloaded(it) }
             ?.mapTo(mutableSetOf()) { it.name }
             ?: emptySet()
 
@@ -204,6 +203,18 @@ object VocableTextToSpeech {
     private fun isVoiceUnavailable(tts: TextToSpeech, voice: Voice): Boolean {
         return tts.isLanguageAvailable(voice.locale) < TextToSpeech.LANG_AVAILABLE
     }
+
+    /**
+     * The engine keeps listing a voice in [TextToSpeech.getVoices] even after its data has been
+     * uninstalled — it's only flagged via [TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED], not
+     * removed from the list. Name/locale matching alone can't tell "installed" from "known but
+     * uninstalled," so this must be checked explicitly wherever a voice is treated as usable.
+     */
+    private fun isVoiceDownloaded(voice: Voice): Boolean = isVoiceDownloaded(voice.features)
+
+    /** Pure/testable half of [isVoiceDownloaded] — operates on the raw feature set, not a real [Voice]. */
+    internal fun isVoiceDownloaded(features: Set<String>?): Boolean =
+        features?.contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED) != true
 
     private fun buildVoiceDisplayName(voice: Voice): String {
         val localeName = voice.locale.displayName

--- a/app/src/test/java/com/willowtree/vocable/core/VocableTextToSpeechTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/core/VocableTextToSpeechTest.kt
@@ -1,7 +1,10 @@
 package com.willowtree.vocable.core
 
+import android.speech.tts.TextToSpeech
 import com.willowtree.vocable.core.VocableTextToSpeech.VoiceResolution
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -62,5 +65,28 @@ class VocableTextToSpeechTest {
         )
 
         assertEquals(VoiceResolution.STALE_FALLBACK_TO_LIVE_DEFAULT, result)
+    }
+
+    // #642: a voice can still be listed by the engine after its data is uninstalled — only
+    // flagged via KEY_FEATURE_NOT_INSTALLED, not removed. Name/locale matching alone can't tell
+    // "installed" from "known but uninstalled."
+
+    @Test
+    fun `voice with no features is considered downloaded`() {
+        assertTrue(VocableTextToSpeech.isVoiceDownloaded(features = null))
+    }
+
+    @Test
+    fun `voice with unrelated features is considered downloaded`() {
+        assertTrue(VocableTextToSpeech.isVoiceDownloaded(features = setOf("someOtherFeature")))
+    }
+
+    @Test
+    fun `voice flagged not-installed is not considered downloaded`() {
+        assertFalse(
+            VocableTextToSpeech.isVoiceDownloaded(
+                features = setOf(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)
+            )
+        )
     }
 }


### PR DESCRIPTION
Part of #613 — closes #642.

> [!NOTE]
> **Based on `feature/voice-selection`**, same as #631/#633 — all sub-issue PRs for this feature target it until the whole thing is ready to ship.

## What

- `VocableTextToSpeech.applySelectedVoice()`'s explicit-match check only verified a selected voice's name, locale, and network-required flag — it never checked whether the voice's data was actually downloaded. Android's TTS engine keeps a voice listed in `getVoices()` even after its data is uninstalled (flagged via `KEY_FEATURE_NOT_INSTALLED`, not removed from the list), so a previously-picked voice that later got uninstalled — the literal scenario #619 describes — would still "match" by name and keep being treated as a valid explicit selection.
- Added `isVoiceDownloaded()` (a `Voice` overload plus a `features: Set<String>?` overload, the latter for unit-testability without needing a real `Voice` instance)
- `applySelectedVoice()`'s `availableVoiceNames` now requires both `isVoiceSupportedForLocale()` and `isVoiceDownloaded()` — an uninstalled voice no longer counts as available, so `resolveVoiceSelection()` correctly returns `STALE_FALLBACK_TO_LIVE_DEFAULT` for it instead of `EXPLICIT`
- `getAvailableVoices()` refactored to reuse the same helper instead of inlining the same check twice
- 3 new unit tests on the pure `isVoiceDownloaded(features)` overload
- `Documentation/work-log/642-stale-voice-download-check.md` added per the work-log standard

## Why it's safe

- 46 unit tests, 0 failures (8 in `VocableTextToSpeechTest`, up from 5)
- `./gradlew clean assembleDebug assembleDebugAndroidTest testDebug` succeeds
- **Verified via real on-device reproduction** on a Google Play emulator image (this repo's testing has otherwise been limited by emulators lacking real TTS engines — this is the first time this specific path was actually exercised, not just reasoned about in code):
  1. Selected a downloaded voice (`en-IN-language`) in Vocable's picker — confirmed via log: `applied voice: en-IN-language`
  2. Uninstalled that voice's data through the OS's own TTS voice manager (Settings → Accessibility → Text-to-speech → Install voice data → English (India) → delete)
  3. **Before this fix**: returning to the app kept logging `applied voice: en-IN-language` with no stale warning — the bug, reproduced live
  4. **After this fix**: same repro now correctly logs the "no longer resolves" warning and falls back to `applied device default voice: en-US-language`
  5. Confirmed the persisted preference actually cleared — Selection Mode's Voice row now shows "Default"
  6. Notably, the fallback engaged **immediately on return to the app, without even a full relaunch** — even more responsive than strictly required, since it's evaluated live on the very next `speak()` call

## Out of scope / follow-up

- On-device validation across 2+ engines (Pixel/Google + Samsung/OEM) — tracked in #634
- UI work (Settings entry points, Change Voice visual rework, Selection Mode removal) — tracked in #635/#636/#637