### PR TITLE
Hide undownloaded voices from the Change Voice picker

### DIFF
--- a/Documentation/work-log/618-hide-undownloaded-voices.md
+++ b/Documentation/work-log/618-hide-undownloaded-voices.md
@@ -1,0 +1,45 @@
+# Hide undownloaded/unavailable voices from the Change Voice picker
+
+**Issue:** #618 (Part of #613)
+
+## What was needed
+
+The Change Voice picker listed voices the device didn't actually have installed, giving them a download-arrow affordance that deep-linked to the OS's TTS voice-data installer (`ACTION_INSTALL_TTS_DATA`). Per iOS parity, undownloaded voices should not appear at all.
+
+iOS confirms the intent: `AVSpeechSynthesisVoice.speechVoices()` only ever reports installed voices, and `VoicePickerViewController` has no download affordance anywhere — the concept of "a voice you could get but don't have" simply doesn't exist in its picker. Android's `TextToSpeech.getVoices()` does surface those, hence the divergence.
+
+## What changed
+
+- **`getAvailableVoices()` now filters through the same predicate as the speak path.** It previously ran its own inline filter checking only language match and `isNetworkConnectionRequired`, while `applySelectedVoice()`/`getActiveVoiceDisplayName()` filtered on the stricter `isVoiceSupportedForLocale() && isVoiceDownloaded()`. Both now call a single `isVoiceUsable()`.
+- **Extracted a pure, testable `isVoiceSupportedForLocale(voiceLanguage, targetLanguage, isNetworkConnectionRequired, languageAvailability)`**, following the same convention already used for `resolveVoiceSelection()` and `isVoiceDownloaded(features)` in this file. Folded away the old `isVoiceUnavailable()` helper.
+- **Removed the download-icon treatment from `VoiceOptionRow`** and the `if (voice.isDownloaded)` fork in its `onClick`, plus the now-unused `onDownloadVoice` screen parameter, its NavHost wiring, and `R.string.voice_download`.
+- **Clamped `pageIndex` when the page count shrinks** in `VoiceSelectionScreen`.
+- **8 new unit tests** on the extracted predicate.
+
+## Key decisions
+
+**The download plumbing was kept, deliberately.** The ticket's AC called for removing `onDownloadVoice()`/`ACTION_INSTALL_TTS_DATA` outright, but the call on the ticket thread was to hide the undownloaded voices "for now" without tearing out the logic. So `VoiceSelectionViewModel.onDownloadVoice()`, `VoiceSelectionEvent.LaunchTtsSettings`, the NavHost intent, `VoiceOption.isDownloaded`, and the existing ViewModel test all remain — the path is simply unreachable from the UI now. Both `onDownloadVoice()` and the `isDownloaded` field carry KDoc saying so, because otherwise they read as deletable dead code to the next person (or the next `/simplify` pass).
+
+**Why route the picker through the speak path's predicate rather than just adding an `isDownloaded` filter.** The narrow fix would have been one extra `.filter { it.isDownloaded }`. Using the shared predicate also closes a latent divergence: the picker could list a voice that `applySelectedVoice()` would immediately classify as `STALE_FALLBACK_TO_LIVE_DEFAULT`, i.e. a user could pick a voice and silently get a different one. The `isLanguageAvailable()` cross-reference matters for the same reason the ticket asked for it — `KEY_FEATURE_NOT_INSTALLED` is inconsistently populated across OEM engines, so `LANG_MISSING_DATA` has to disqualify a voice on its own.
+
+**`isVoiceSupportedForLocale` and `isVoiceUsable` are kept as two predicates, not merged.** `applyLiveDefaultVoice()` intentionally checks locale support *without* the download check — it applies whatever the engine reports as its own default rather than second-guessing the engine's install state. Merging them would have changed that fallback's behavior, which is outside this ticket.
+
+**Network-required voices stay excluded unconditionally,** not just while offline. The AC says "treated as unavailable offline," but Vocable is offline/local-first, and a voice that can drop out mid-conversation isn't something to hand a user who depends on it to speak. This was already the pre-existing behavior; it's unchanged.
+
+**The pagination clamp.** `onRefreshVoices()` re-reads installed voices on every `ON_RESUME`, so uninstalling a voice in system Settings and returning to Vocable shrinks the list. `currentPageItems` uses `getOrElse { emptyList() }`, so a stale out-of-range `pageIndex` rendered a blank page. Pre-existing, but hiding undownloaded voices makes the list shrink more often, so it's fixed here rather than left to be rediscovered.
+
+## Testing
+
+`./gradlew testDebug` — green, 16 tests in `VocableTextToSpeechTest` (8 new).
+
+Unit coverage is on the extracted pure predicate only. The voice-list side of `VoiceSelectionViewModel` still can't be asserted against real data: `VocableTextToSpeech` is a global object wrapping the real Android engine, so under JVM tests it never initializes and `getAvailableVoices()` returns empty. That limitation is already documented in `VoiceSelectionViewModelTest`'s header comment; closing it would need an injected seam on the ViewModel.
+
+**AC5 ("filter behavior confirmed on 2+ engines/OEMs") is not met.** #634, the spike that AC defers to, closed with second-engine/OEM validation *explicitly deferred* — its own finding was that no Google-engine divergence broke the fallback logic, so per that ticket's rules there was nothing to file, and multi-engine testing was left to "revisit only if a future report suggests engine-specific breakage." The `isLanguageAvailable()` cross-reference is in place precisely because per-engine `KEY_FEATURE_NOT_INSTALLED` behavior is untrusted, but that reasoning has not been confirmed against a non-Google engine on real hardware.
+
+Also worth noting: #634's comment cites `.claude/skills/tts-voice-validation/SKILL.md` as the durable record of the `getDefaultVoice()` observability limit, but that file was never committed on any branch — so that finding currently lives only in the GitHub comment.
+
+## Pointers
+
+- Issue: #618 · Parent: #613
+- Related: #634 (cross-engine validation spike), #636 (visual rework), #642/#645 (`isVoiceDownloaded`, reused here)
+- iOS reference: `Vocable/Features/Settings/VoiceSettings/VoiceProfilePreviewDataSource.swift` + `…+Filter.swift`

--- a/Documentation/work-log/618-hide-undownloaded-voices.md
+++ b/Documentation/work-log/618-hide-undownloaded-voices.md
@@ -14,7 +14,7 @@ iOS confirms the intent: `AVSpeechSynthesisVoice.speechVoices()` only ever repor
 - **Extracted a pure, testable `isVoiceSupportedForLocale(voiceLanguage, targetLanguage, isNetworkConnectionRequired, languageAvailability)`**, following the same convention already used for `resolveVoiceSelection()` and `isVoiceDownloaded(features)` in this file. Folded away the old `isVoiceUnavailable()` helper.
 - **Removed the download-icon treatment from `VoiceOptionRow`** and the `if (voice.isDownloaded)` fork in its `onClick`, plus the now-unused `onDownloadVoice` screen parameter, its NavHost wiring, and `R.string.voice_download`.
 - **Clamped `pageIndex` when the page count shrinks** in `VoiceSelectionScreen`.
-- **8 new unit tests** on the extracted predicate.
+- **11 new unit tests** on the extracted predicate.
 
 ## Key decisions
 
@@ -26,11 +26,13 @@ iOS confirms the intent: `AVSpeechSynthesisVoice.speechVoices()` only ever repor
 
 **Network-required voices stay excluded unconditionally,** not just while offline. The AC says "treated as unavailable offline," but Vocable is offline/local-first, and a voice that can drop out mid-conversation isn't something to hand a user who depends on it to speak. This was already the pre-existing behavior; it's unchanged.
 
+**`languageAvailability` is passed as a lambda, and checked last.** Routing the picker through the speak path's predicate means `isLanguageAvailable()` — a synchronous binder call into the TTS service — now runs per entry in `getVoices()`, which is several hundred voices on Google TTS, on the main thread for every `speak()`. Reordering `isVoiceUsable()` to check the local install flag first and deferring the availability call behind a `() -> Int` keeps the IPC to only the voices that already match the target language and are local. Three tests count invocations so a refactor back to an eager `Int` parameter — which Kotlin would evaluate for every candidate — fails loudly instead of silently reintroducing N IPCs per call.
+
 **The pagination clamp.** `onRefreshVoices()` re-reads installed voices on every `ON_RESUME`, so uninstalling a voice in system Settings and returning to Vocable shrinks the list. `currentPageItems` uses `getOrElse { emptyList() }`, so a stale out-of-range `pageIndex` rendered a blank page. Pre-existing, but hiding undownloaded voices makes the list shrink more often, so it's fixed here rather than left to be rediscovered.
 
 ## Testing
 
-`./gradlew testDebug` — green, 16 tests in `VocableTextToSpeechTest` (8 new).
+`./gradlew testDebug` — green, 75 tests overall, 19 in `VocableTextToSpeechTest` (11 new). `./gradlew assembleDebug assembleDebugAndroidTest` — green.
 
 Unit coverage is on the extracted pure predicate only. The voice-list side of `VoiceSelectionViewModel` still can't be asserted against real data: `VocableTextToSpeech` is a global object wrapping the real Android engine, so under JVM tests it never initializes and `getAvailableVoices()` returns empty. That limitation is already documented in `VoiceSelectionViewModelTest`'s header comment; closing it would need an injected seam on the ViewModel.
 

--- a/app/src/main/java/com/willowtree/vocable/core/VocableTextToSpeech.kt
+++ b/app/src/main/java/com/willowtree/vocable/core/VocableTextToSpeech.kt
@@ -18,6 +18,11 @@ object VocableTextToSpeech {
         val name: String,
         val displayName: String,
         val locale: Locale,
+        /**
+         * Always true for options coming out of [getAvailableVoices] since #618 — undownloaded
+         * voices are filtered out rather than flagged. Kept so the picker can go back to showing
+         * them without replumbing; see [com.willowtree.vocable.ui.voiceselection.VoiceSelectionViewModel.onDownloadVoice].
+         */
         val isDownloaded: Boolean = true
     )
 
@@ -81,16 +86,22 @@ object VocableTextToSpeech {
         _isSpeakingFlow.value = false
     }
 
+    /**
+     * The voices to offer in the Change Voice picker: only ones actually installed and usable on
+     * this device right now. Undownloaded voices are omitted entirely rather than surfaced with a
+     * download affordance (#618) — matching iOS, whose `AVSpeechSynthesisVoice.speechVoices()` only
+     * ever reports installed voices. Users are pointed at the OS for downloads instead, via the
+     * Settings → Voice footer copy.
+     *
+     * Filters through the same [isVoiceUsable] predicate as the speak path, so the picker can't
+     * list a voice that [applySelectedVoice] would then treat as stale.
+     */
     fun getAvailableVoices(locale: Locale = Locale.getDefault()): List<VoiceOption> {
         val tts = textToSpeech ?: return emptyList()
         val availableVoices = tts.voices ?: return emptyList()
 
         return availableVoices
-            .filter { voice ->
-                val voiceLocale = voice.locale ?: return@filter false
-                voiceLocale.language.equals(locale.language, ignoreCase = true) &&
-                    !voice.isNetworkConnectionRequired
-            }
+            .filter { isVoiceUsable(tts, it, locale) }
             .sortedWith(compareByDescending<Voice> { it.quality }.thenBy { it.name })
             .map { voice ->
                 VoiceOption(
@@ -116,7 +127,7 @@ object VocableTextToSpeech {
         val tts = textToSpeech ?: return null
 
         val candidateVoices = tts.voices
-            ?.filter { isVoiceSupportedForLocale(tts, it, locale) && isVoiceDownloaded(it) }
+            ?.filter { isVoiceUsable(tts, it, locale) }
             ?: return null
         val availableVoiceNames = candidateVoices.mapTo(mutableSetOf()) { it.name }
 
@@ -192,7 +203,7 @@ object VocableTextToSpeech {
      */
     private fun applySelectedVoice(tts: TextToSpeech, selectedVoiceName: String?, locale: Locale): Boolean {
         val availableVoiceNames = tts.voices
-            ?.filter { isVoiceSupportedForLocale(tts, it, locale) && isVoiceDownloaded(it) }
+            ?.filter { isVoiceUsable(tts, it, locale) }
             ?.mapTo(mutableSetOf()) { it.name }
             ?: emptySet()
 
@@ -228,15 +239,49 @@ object VocableTextToSpeech {
         }
     }
 
+    /**
+     * The full "can Vocable actually speak with this voice right now" predicate: supported for
+     * [locale] *and* installed on-device. This is what both the picker ([getAvailableVoices]) and
+     * the speak path ([applySelectedVoice]) filter on, so the two can't disagree about whether a
+     * given voice exists.
+     */
+    private fun isVoiceUsable(tts: TextToSpeech, voice: Voice, locale: Locale): Boolean =
+        isVoiceSupportedForLocale(tts, voice, locale) && isVoiceDownloaded(voice)
+
+    /**
+     * Locale/network support only — deliberately says nothing about download status, unlike
+     * [isVoiceUsable]. Kept separate for the live-device-default fallback, which applies whatever
+     * the engine reports as its own default rather than second-guessing its install state.
+     */
     private fun isVoiceSupportedForLocale(tts: TextToSpeech, voice: Voice, locale: Locale): Boolean {
         val voiceLocale = voice.locale ?: return false
-        val languageMatches = voiceLocale.language.equals(locale.language, ignoreCase = true)
-        return languageMatches && !voice.isNetworkConnectionRequired && !isVoiceUnavailable(tts, voice)
+        return isVoiceSupportedForLocale(
+            voiceLanguage = voiceLocale.language,
+            targetLanguage = locale.language,
+            isNetworkConnectionRequired = voice.isNetworkConnectionRequired,
+            languageAvailability = tts.isLanguageAvailable(voiceLocale)
+        )
     }
 
-    private fun isVoiceUnavailable(tts: TextToSpeech, voice: Voice): Boolean {
-        return tts.isLanguageAvailable(voice.locale) < TextToSpeech.LANG_AVAILABLE
-    }
+    /**
+     * Pure/testable half of [isVoiceSupportedForLocale] — takes the raw values off a [Voice] rather
+     * than a real one, for the same reason as [resolveVoiceSelection].
+     *
+     * [languageAvailability] is a [TextToSpeech.isLanguageAvailable] result. It's the cross-reference
+     * that makes the install check trustworthy: `KEY_FEATURE_NOT_INSTALLED` (see [isVoiceDownloaded])
+     * is inconsistently populated across OEM engines, so a `LANG_MISSING_DATA` result is treated as
+     * "not present here" on its own.
+     */
+    internal fun isVoiceSupportedForLocale(
+        voiceLanguage: String?,
+        targetLanguage: String,
+        isNetworkConnectionRequired: Boolean,
+        languageAvailability: Int
+    ): Boolean =
+        voiceLanguage != null &&
+            voiceLanguage.equals(targetLanguage, ignoreCase = true) &&
+            !isNetworkConnectionRequired &&
+            languageAvailability >= TextToSpeech.LANG_AVAILABLE
 
     /**
      * The engine keeps listing a voice in [TextToSpeech.getVoices] even after its data has been

--- a/app/src/main/java/com/willowtree/vocable/core/VocableTextToSpeech.kt
+++ b/app/src/main/java/com/willowtree/vocable/core/VocableTextToSpeech.kt
@@ -246,7 +246,10 @@ object VocableTextToSpeech {
      * given voice exists.
      */
     private fun isVoiceUsable(tts: TextToSpeech, voice: Voice, locale: Locale): Boolean =
-        isVoiceSupportedForLocale(tts, voice, locale) && isVoiceDownloaded(voice)
+        // Install check first: it's a local feature-set lookup, whereas the locale check ends in a
+        // binder call into the TTS service. Order is behaviourally irrelevant (both are pure), but
+        // this way undownloaded voices are rejected without paying for the IPC.
+        isVoiceDownloaded(voice) && isVoiceSupportedForLocale(tts, voice, locale)
 
     /**
      * Locale/network support only — deliberately says nothing about download status, unlike
@@ -259,7 +262,7 @@ object VocableTextToSpeech {
             voiceLanguage = voiceLocale.language,
             targetLanguage = locale.language,
             isNetworkConnectionRequired = voice.isNetworkConnectionRequired,
-            languageAvailability = tts.isLanguageAvailable(voiceLocale)
+            languageAvailability = { tts.isLanguageAvailable(voiceLocale) }
         )
     }
 
@@ -267,21 +270,27 @@ object VocableTextToSpeech {
      * Pure/testable half of [isVoiceSupportedForLocale] — takes the raw values off a [Voice] rather
      * than a real one, for the same reason as [resolveVoiceSelection].
      *
-     * [languageAvailability] is a [TextToSpeech.isLanguageAvailable] result. It's the cross-reference
-     * that makes the install check trustworthy: `KEY_FEATURE_NOT_INSTALLED` (see [isVoiceDownloaded])
-     * is inconsistently populated across OEM engines, so a `LANG_MISSING_DATA` result is treated as
-     * "not present here" on its own.
+     * [languageAvailability] supplies a [TextToSpeech.isLanguageAvailable] result. It's the
+     * cross-reference that makes the install check trustworthy: `KEY_FEATURE_NOT_INSTALLED` (see
+     * [isVoiceDownloaded]) is inconsistently populated across OEM engines, so a `LANG_MISSING_DATA`
+     * result is treated as "not present here" on its own.
+     *
+     * It's a lambda, and checked last, because the real implementation is a synchronous binder call
+     * into the TTS service and this predicate runs once per entry in [TextToSpeech.getVoices] —
+     * several hundred on Google TTS — on the main thread for every [speak]. Only voices that already
+     * match the target language and are local should pay for it. Don't inline it back to an `Int`
+     * parameter: Kotlin evaluates arguments eagerly, so that reintroduces N IPCs per call.
      */
     internal fun isVoiceSupportedForLocale(
         voiceLanguage: String?,
         targetLanguage: String,
         isNetworkConnectionRequired: Boolean,
-        languageAvailability: Int
+        languageAvailability: () -> Int
     ): Boolean =
         voiceLanguage != null &&
             voiceLanguage.equals(targetLanguage, ignoreCase = true) &&
             !isNetworkConnectionRequired &&
-            languageAvailability >= TextToSpeech.LANG_AVAILABLE
+            languageAvailability() >= TextToSpeech.LANG_AVAILABLE
 
     /**
      * The engine keeps listing a voice in [TextToSpeech.getVoices] even after its data has been

--- a/app/src/main/java/com/willowtree/vocable/ui/VocableNavHost.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/VocableNavHost.kt
@@ -267,7 +267,6 @@ fun VocableNavHost(
                     state = state,
                     onBack = { navController.popBackStack() },
                     onVoiceSelected = viewModel::onVoiceSelected,
-                    onDownloadVoice = viewModel::onDownloadVoice,
                     onRefreshVoices = viewModel::refreshVoices,
                     onPreviewVoice = viewModel::onPreviewVoice
                 )

--- a/app/src/main/java/com/willowtree/vocable/ui/voiceselection/VoiceSelectionScreen.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/voiceselection/VoiceSelectionScreen.kt
@@ -50,7 +50,6 @@ fun VoiceSelectionScreen(
     state: VoiceSelectionState,
     onBack: () -> Unit,
     onVoiceSelected: (String?) -> Unit,
-    onDownloadVoice: () -> Unit,
     onRefreshVoices: () -> Unit,
     onPreviewVoice: (VocableTextToSpeech.VoiceOption) -> Unit,
     modifier: Modifier = Modifier
@@ -82,6 +81,14 @@ fun VoiceSelectionScreen(
     val totalPages = remember(state.voices, itemsPerPage) {
         maxOf(1, ceil(state.voices.size.toFloat() / itemsPerPage).toInt())
     }
+    // The list can shrink underneath us: onRefreshVoices() re-reads the installed voices on every
+    // ON_RESUME, so uninstalling a voice in system Settings and returning to Vocable drops the
+    // count — and #618 now hides undownloaded voices outright rather than leaving a greyed row
+    // behind. Without this clamp, an out-of-range pageIndex renders a blank page.
+    LaunchedEffect(totalPages) {
+        if (pageIndex >= totalPages) pageIndex = totalPages - 1
+    }
+
     val currentPageItems = remember(state.voices, pageIndex, itemsPerPage) {
         state.voices.chunked(itemsPerPage).getOrElse(pageIndex) { emptyList() }
     }
@@ -141,13 +148,7 @@ fun VoiceSelectionScreen(
                             isSelected = state.selectedVoiceName == voice.name,
                             isLandscape = isLandscape,
                             isPlaying = state.previewingVoiceName == voice.name,
-                            onClick = {
-                                if (voice.isDownloaded) {
-                                    onVoiceSelected(voice.name)
-                                } else {
-                                    onDownloadVoice()
-                                }
-                            },
+                            onClick = { onVoiceSelected(voice.name) },
                             onPreviewClick = { onPreviewVoice(voice) },
                             modifier = Modifier.fillMaxWidth().height(rowHeight)
                         )
@@ -255,12 +256,8 @@ private fun VoiceOptionRow(
                     style = MaterialTheme.typography.titleMedium,
                     modifier = Modifier.weight(1f)
                 )
-                when {
-                    !voice.isDownloaded -> Icon(
-                        painter = painterResource(id = R.drawable.ic_arrow_down_40dp),
-                        contentDescription = stringResource(R.string.voice_download)
-                    )
-                    isSelected -> Icon(
+                if (isSelected) {
+                    Icon(
                         painter = painterResource(id = R.drawable.ic_check_40dp),
                         contentDescription = stringResource(R.string.selected)
                     )
@@ -277,14 +274,13 @@ private fun VoiceSelectionScreenPreview() {
         VoiceSelectionScreen(
             state = VoiceSelectionState(
                 voices = listOf(
-                    VocableTextToSpeech.VoiceOption("voice_1", "English (United States) – Enhanced", java.util.Locale.US, isDownloaded = true),
-                    VocableTextToSpeech.VoiceOption("voice_2", "English (United States) – Standard", java.util.Locale.US, isDownloaded = false)
+                    VocableTextToSpeech.VoiceOption("voice_1", "English (United States) – Enhanced", java.util.Locale.US),
+                    VocableTextToSpeech.VoiceOption("voice_2", "English (United States) – Standard", java.util.Locale.US)
                 ),
                 selectedVoiceName = "voice_1"
             ),
             onBack = {},
             onVoiceSelected = {},
-            onDownloadVoice = {},
             onRefreshVoices = {},
             onPreviewVoice = {}
         )
@@ -299,7 +295,6 @@ private fun VoiceSelectionScreenEmptyPreview() {
             state = VoiceSelectionState(voices = emptyList(), selectedVoiceName = null),
             onBack = {},
             onVoiceSelected = {},
-            onDownloadVoice = {},
             onRefreshVoices = {},
             onPreviewVoice = {}
         )

--- a/app/src/main/java/com/willowtree/vocable/ui/voiceselection/VoiceSelectionViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/voiceselection/VoiceSelectionViewModel.kt
@@ -39,6 +39,13 @@ class VoiceSelectionViewModel(
         sendEvent(VoiceSelectionEvent.NavigateBack)
     }
 
+    /**
+     * Deep-links to the OS's TTS voice-data installer. Currently unreachable from the UI: #618 hides
+     * undownloaded voices from the picker entirely (per iOS parity), so no row can trigger a
+     * download anymore. Retained deliberately — the call there was to hide the undownloaded voices
+     * "for now" without tearing out the plumbing, so restoring the affordance stays a one-line
+     * change. Don't delete as dead code without checking #618 first.
+     */
     fun onDownloadVoice() {
         sendEvent(VoiceSelectionEvent.LaunchTtsSettings(VocableTextToSpeech.getCurrentEngine()))
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,7 +39,6 @@
     <!-- Change Voice -->
     <string name="close_voice_selection">Close Change Voice</string>
     <string name="selected">Selected</string>
-    <string name="voice_download">Download voice</string>
     <string name="voice_empty_title">No Voices</string>
     <string name="voice_empty_description">No voices that match your language and region settings are installed.</string>
 

--- a/app/src/test/java/com/willowtree/vocable/core/VocableTextToSpeechTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/core/VocableTextToSpeechTest.kt
@@ -104,7 +104,7 @@ class VocableTextToSpeechTest {
         voiceLanguage = voiceLanguage,
         targetLanguage = targetLanguage,
         isNetworkConnectionRequired = isNetworkConnectionRequired,
-        languageAvailability = languageAvailability
+        languageAvailability = { languageAvailability }
     )
 
     @Test
@@ -153,5 +153,44 @@ class VocableTextToSpeechTest {
     @Test
     fun `voice whose language is not supported by the engine is not supported`() {
         assertFalse(isSupported(languageAvailability = TextToSpeech.LANG_NOT_SUPPORTED))
+    }
+
+    /**
+     * `languageAvailability` wraps a synchronous binder call into the TTS service, and this predicate
+     * runs once per entry in `getVoices()` — several hundred on Google TTS — on the main thread for
+     * every `speak()`. These two pin the short-circuiting so it can't be lost again to a refactor
+     * that passes the value eagerly instead of the lambda.
+     */
+    private fun countingIsSupported(
+        voiceLanguage: String? = "en",
+        isNetworkConnectionRequired: Boolean = false
+    ): Int {
+        var calls = 0
+        VocableTextToSpeech.isVoiceSupportedForLocale(
+            voiceLanguage = voiceLanguage,
+            targetLanguage = "en",
+            isNetworkConnectionRequired = isNetworkConnectionRequired,
+            languageAvailability = {
+                calls++
+                TextToSpeech.LANG_AVAILABLE
+            }
+        )
+        return calls
+    }
+
+    @Test
+    fun `language availability is not queried for a voice in another language`() {
+        assertEquals(0, countingIsSupported(voiceLanguage = "fr"))
+        assertEquals(0, countingIsSupported(voiceLanguage = null))
+    }
+
+    @Test
+    fun `language availability is not queried for a network-required voice`() {
+        assertEquals(0, countingIsSupported(isNetworkConnectionRequired = true))
+    }
+
+    @Test
+    fun `language availability is queried once for an otherwise-eligible voice`() {
+        assertEquals(1, countingIsSupported())
     }
 }

--- a/app/src/test/java/com/willowtree/vocable/core/VocableTextToSpeechTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/core/VocableTextToSpeechTest.kt
@@ -89,4 +89,69 @@ class VocableTextToSpeechTest {
             )
         )
     }
+
+    // #618: the picker shows only voices actually installed and usable on-device — undownloaded
+    // ones are hidden outright rather than offered with a download prompt. `isVoiceSupportedForLocale`
+    // is the locale/network/language-data half of that filter; `isVoiceDownloaded` above is the
+    // install half. Both must pass for a voice to reach the list.
+
+    private fun isSupported(
+        voiceLanguage: String? = "en",
+        targetLanguage: String = "en",
+        isNetworkConnectionRequired: Boolean = false,
+        languageAvailability: Int = TextToSpeech.LANG_AVAILABLE
+    ) = VocableTextToSpeech.isVoiceSupportedForLocale(
+        voiceLanguage = voiceLanguage,
+        targetLanguage = targetLanguage,
+        isNetworkConnectionRequired = isNetworkConnectionRequired,
+        languageAvailability = languageAvailability
+    )
+
+    @Test
+    fun `local voice matching the target language with data present is supported`() {
+        assertTrue(isSupported())
+    }
+
+    @Test
+    fun `language match is case-insensitive`() {
+        assertTrue(isSupported(voiceLanguage = "EN", targetLanguage = "en"))
+    }
+
+    @Test
+    fun `country-specific language availability still counts as supported`() {
+        assertTrue(isSupported(languageAvailability = TextToSpeech.LANG_COUNTRY_VAR_AVAILABLE))
+    }
+
+    @Test
+    fun `voice for a different language is not supported`() {
+        assertFalse(isSupported(voiceLanguage = "fr", targetLanguage = "en"))
+    }
+
+    @Test
+    fun `voice with no locale is not supported`() {
+        assertFalse(isSupported(voiceLanguage = null))
+    }
+
+    /**
+     * Network voices are excluded unconditionally, not just while offline: Vocable is an
+     * offline/local-first app, so a voice that needs a connection can't be relied on mid-conversation.
+     */
+    @Test
+    fun `network-required voice is not supported`() {
+        assertFalse(isSupported(isNetworkConnectionRequired = true))
+    }
+
+    /**
+     * The cross-reference that makes the hide-undownloaded filter trustworthy — `KEY_FEATURE_NOT_INSTALLED`
+     * is inconsistently populated across OEM engines, so missing language data alone disqualifies a voice.
+     */
+    @Test
+    fun `voice whose language data is missing is not supported`() {
+        assertFalse(isSupported(languageAvailability = TextToSpeech.LANG_MISSING_DATA))
+    }
+
+    @Test
+    fun `voice whose language is not supported by the engine is not supported`() {
+        assertFalse(isSupported(languageAvailability = TextToSpeech.LANG_NOT_SUPPORTED))
+    }
 }


### PR DESCRIPTION
## Summary
- `getAvailableVoices()` now filters through the same `isVoiceUsable()` predicate as the speak path (locale support + `isLanguageAvailable()` cross-reference + `KEY_FEATURE_NOT_INSTALLED`), so undownloaded voices are hidden outright instead of listed with a download-arrow affordance. This also closes a latent divergence where the picker could offer a voice `applySelectedVoice()` would immediately treat as stale.
- Removed the download-icon treatment and the `isDownloaded` fork in `VoiceOptionRow`'s `onClick`, plus the `onDownloadVoice` screen param, its NavHost wiring, and `R.string.voice_download`.
- Deferred `isLanguageAvailable()` behind a `() -> Int` checked last — it's a synchronous binder call that would otherwise run once per entry in `getVoices()` (several hundred on Google TTS) on the main thread for every `speak()`.
- Clamped `pageIndex` when the page count shrinks, since the `ON_RESUME` refresh can now drop the voice count and an out-of-range index rendered a blank page.

## Ticket
Part of #613 — closes #618

Work log: `Documentation/work-log/618-hide-undownloaded-voices.md`

### Two AC gaps, both deliberate

**AC3 ("removing `onDownloadVoice()`/`ACTION_INSTALL_TTS_DATA`") is intentionally not met.** Per @Mansimran-Singh's call on the ticket — hide the undownloaded voices for now without tearing out the logic — `VoiceSelectionViewModel.onDownloadVoice()`, `VoiceSelectionEvent.LaunchTtsSettings`, the NavHost intent and `VoiceOption.isDownloaded` all remain, simply unreachable from the UI. Both carry KDoc pointing at #618 so they don't read as deletable dead code. @rhyslutsky's Product AC still holds behaviorally: no download icon, prompt, or deep-link is reachable anywhere on the Voice Selection screen.

**AC5 (filter behavior confirmed on 2+ engines/OEMs) is not met.** #634, the spike this AC defers to, closed with second-engine/OEM validation explicitly deferred. The `isLanguageAvailable()` cross-reference is in place precisely because `KEY_FEATURE_NOT_INSTALLED` is inconsistently populated across OEM engines, but that reasoning has not been confirmed against a non-Google engine on real hardware.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] Refactor
- [x] Tests
- [ ] CI/CD
- [x] Documentation

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

`VocableTextToSpeechTest` goes 8 → 19 tests. Coverage is on the extracted pure predicates only — `VocableTextToSpeech` is a global object wrapping the real Android engine, so under JVM tests it never initializes and `getAvailableVoices()` returns empty. That limitation is already documented in `VoiceSelectionViewModelTest`'s header; closing it would need an injected seam on the ViewModel.

Three of the new tests count `languageAvailability` invocations, so a refactor back to an eager `Int` parameter — which Kotlin would evaluate for every candidate — fails loudly instead of silently reintroducing N IPCs per `speak()`.

## Checklist
- [x] Tests pass locally (`./gradlew testDebug` — 75 tests, 0 failures; `./gradlew assembleDebug assembleDebugAndroidTest` also green)
- [x] No API keys or secrets in code
- [ ] CLAUDE.md updated (if new pattern introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)