### PR TITLE
Change Voice: speak a sample phrase for voice preview

### DIFF
--- a/app/src/main/java/com/willowtree/vocable/core/VocableTextToSpeech.kt
+++ b/app/src/main/java/com/willowtree/vocable/core/VocableTextToSpeech.kt
@@ -85,17 +85,22 @@ object VocableTextToSpeech {
         val tts = textToSpeech ?: return emptyList()
         val availableVoices = tts.voices ?: return emptyList()
 
-        return availableVoices
-            .filter { voice ->
-                val voiceLocale = voice.locale ?: return@filter false
-                voiceLocale.language.equals(locale.language, ignoreCase = true) &&
-                    !voice.isNetworkConnectionRequired
-            }
+        val matchingVoices = availableVoices.filter { voice ->
+            val voiceLocale = voice.locale ?: return@filter false
+            voiceLocale.language.equals(locale.language, ignoreCase = true) &&
+                !voice.isNetworkConnectionRequired
+        }
+
+        val displayNamesByVoiceName = buildVoiceDisplayNames(
+            matchingVoices.map { VoiceLabelInput(it.name, it.locale.displayName, it.quality) }
+        )
+
+        return matchingVoices
             .sortedWith(compareByDescending<Voice> { it.quality }.thenBy { it.name })
             .map { voice ->
                 VoiceOption(
                     name = voice.name,
-                    displayName = buildVoiceDisplayName(voice),
+                    displayName = displayNamesByVoiceName.getValue(voice.name),
                     locale = voice.locale,
                     isDownloaded = isVoiceDownloaded(voice)
                 )
@@ -120,13 +125,15 @@ object VocableTextToSpeech {
             ?: return null
         val availableVoiceNames = candidateVoices.mapTo(mutableSetOf()) { it.name }
 
-        val resolvedVoice = when (resolveVoiceSelection(selectedVoiceName, availableVoiceNames)) {
-            VoiceResolution.EXPLICIT -> candidateVoices.firstOrNull { it.name == selectedVoiceName }
+        val resolvedVoiceName = when (resolveVoiceSelection(selectedVoiceName, availableVoiceNames)) {
+            VoiceResolution.EXPLICIT -> selectedVoiceName
             VoiceResolution.LIVE_DEFAULT, VoiceResolution.STALE_FALLBACK_TO_LIVE_DEFAULT ->
-                tts.getDefaultVoice()?.takeIf { isVoiceSupportedForLocale(tts, it, locale) }
-        }
+                tts.defaultVoice?.takeIf { isVoiceSupportedForLocale(tts, it, locale) }?.name
+        } ?: return null
 
-        return resolvedVoice?.let { buildVoiceDisplayName(it) }
+        // Reuses getAvailableVoices() as the single source of truth for numbering, so the active
+        // voice's label always matches what's shown for it in the Change Voice picker.
+        return getAvailableVoices(locale).firstOrNull { it.name == resolvedVoiceName }?.displayName
     }
 
     /**
@@ -250,13 +257,22 @@ object VocableTextToSpeech {
     internal fun isVoiceDownloaded(features: Set<String>?): Boolean =
         features?.contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED) != true
 
-    private fun buildVoiceDisplayName(voice: Voice): String {
-        val localeName = voice.locale.displayName
-        val qualityLabel = when {
-            voice.quality >= Voice.QUALITY_VERY_HIGH -> "Enhanced"
-            voice.quality >= Voice.QUALITY_HIGH -> "High Quality"
-            else -> "Standard"
-        }
-        return "$localeName – $qualityLabel"
-    }
+    /** A voice's attributes needed to number it for display — kept free of [Voice] so it's unit-testable. */
+    internal data class VoiceLabelInput(val name: String, val localeDisplayName: String, val quality: Int)
+
+    /**
+     * Android's TTS `Voice` API has no human-friendly name (unlike iOS's `AVSpeechSynthesisVoice.name`),
+     * so each voice is labeled by locale plus an ordinal within that locale instead — e.g.
+     * "English (United States) Voice 1", "Voice 2" — assigned in the same order used to display the
+     * list elsewhere (quality desc, then name). A previous quality-word label ("Enhanced"/"Standard")
+     * used an en-dash that some TTS engines mis-speak when interpolated into a preview sample.
+     */
+    internal fun buildVoiceDisplayNames(voices: List<VoiceLabelInput>): Map<String, String> =
+        voices
+            .sortedWith(compareByDescending<VoiceLabelInput> { it.quality }.thenBy { it.name })
+            .groupBy { it.localeDisplayName }
+            .flatMap { (localeName, localeVoices) ->
+                localeVoices.mapIndexed { index, voice -> voice.name to "$localeName Voice ${index + 1}" }
+            }
+            .toMap()
 }

--- a/app/src/main/java/com/willowtree/vocable/ui/settingsvoice/SettingsVoiceScreen.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/settingsvoice/SettingsVoiceScreen.kt
@@ -165,7 +165,7 @@ fun SettingsVoiceScreen(
 fun SettingsVoiceScreenPreview() {
     VocableTheme {
         SettingsVoiceScreen(
-            state = SettingsVoiceState(activeVoiceDisplayName = "English (United States) – Enhanced"),
+            state = SettingsVoiceState(activeVoiceDisplayName = "English (United States) Voice 1"),
             onBack = {},
             onChangeVoice = {},
             onRefreshActiveVoice = {},

--- a/app/src/main/java/com/willowtree/vocable/ui/voiceselection/VoiceSelectionScreen.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/voiceselection/VoiceSelectionScreen.kt
@@ -52,9 +52,10 @@ fun VoiceSelectionScreen(
     onVoiceSelected: (String?) -> Unit,
     onDownloadVoice: () -> Unit,
     onRefreshVoices: () -> Unit,
-    onPreviewVoice: (VocableTextToSpeech.VoiceOption) -> Unit,
+    onPreviewVoice: (VocableTextToSpeech.VoiceOption, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val previewSampleFormat = stringResource(R.string.voice_preview_sample)
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -148,7 +149,7 @@ fun VoiceSelectionScreen(
                                     onDownloadVoice()
                                 }
                             },
-                            onPreviewClick = { onPreviewVoice(voice) },
+                            onPreviewClick = { onPreviewVoice(voice, previewSampleFormat) },
                             modifier = Modifier.fillMaxWidth().height(rowHeight)
                         )
                     }
@@ -199,10 +200,9 @@ private fun VoiceSelectionEmptyState(modifier: Modifier = Modifier) {
 }
 
 /**
- * Tapping the play chip reads [voice]'s own display name aloud in that voice — not a sample phrase,
- * so it sidesteps #613's still-open sample-phrase decision. It toggles to the stop icon while
- * speaking (driven by [isPlaying], sourced from the global `VocableTextToSpeech.isSpeakingFlow`) and
- * back to play once done.
+ * Tapping the play chip speaks a fixed sample phrase (`voice_preview_sample`, with [voice]'s display
+ * name substituted in) in that voice. It toggles to the stop icon while speaking (driven by
+ * [isPlaying], sourced from the global `VocableTextToSpeech.isSpeakingFlow`) and back to play once done.
  */
 @Composable
 private fun VoiceOptionRow(
@@ -277,8 +277,8 @@ private fun VoiceSelectionScreenPreview() {
         VoiceSelectionScreen(
             state = VoiceSelectionState(
                 voices = listOf(
-                    VocableTextToSpeech.VoiceOption("voice_1", "English (United States) – Enhanced", java.util.Locale.US, isDownloaded = true),
-                    VocableTextToSpeech.VoiceOption("voice_2", "English (United States) – Standard", java.util.Locale.US, isDownloaded = false)
+                    VocableTextToSpeech.VoiceOption("voice_1", "English (United States) Voice 1", java.util.Locale.US, isDownloaded = true),
+                    VocableTextToSpeech.VoiceOption("voice_2", "English (United States) Voice 2", java.util.Locale.US, isDownloaded = false)
                 ),
                 selectedVoiceName = "voice_1"
             ),
@@ -286,7 +286,7 @@ private fun VoiceSelectionScreenPreview() {
             onVoiceSelected = {},
             onDownloadVoice = {},
             onRefreshVoices = {},
-            onPreviewVoice = {}
+            onPreviewVoice = { _, _ -> }
         )
     }
 }
@@ -301,7 +301,7 @@ private fun VoiceSelectionScreenEmptyPreview() {
             onVoiceSelected = {},
             onDownloadVoice = {},
             onRefreshVoices = {},
-            onPreviewVoice = {}
+            onPreviewVoice = { _, _ -> }
         )
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/ui/voiceselection/VoiceSelectionViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/voiceselection/VoiceSelectionViewModel.kt
@@ -43,14 +43,19 @@ class VoiceSelectionViewModel(
         sendEvent(VoiceSelectionEvent.LaunchTtsSettings(VocableTextToSpeech.getCurrentEngine()))
     }
 
-    /** Toggles reading [voice]'s own display name aloud in that voice — stops if it's already previewing. */
-    fun onPreviewVoice(voice: VocableTextToSpeech.VoiceOption) {
+    /**
+     * Toggles playing [voice]'s preview sample aloud in that voice — stops if it's already
+     * previewing. [sampleFormat] is `voice_preview_sample` (e.g. `"Hello, this is Vocable, %1$s."`),
+     * resolved by the caller so this stays free of Android resource access; [voice]'s display name
+     * (not its raw engine identifier) is substituted into it.
+     */
+    fun onPreviewVoice(voice: VocableTextToSpeech.VoiceOption, sampleFormat: String) {
         if (uiState.value.previewingVoiceName == voice.name) {
             VocableTextToSpeech.stop()
             updateState { copy(previewingVoiceName = null) }
         } else {
             updateState { copy(previewingVoiceName = voice.name) }
-            VocableTextToSpeech.speak(voice.locale, voice.displayName, voice.name)
+            VocableTextToSpeech.speak(voice.locale, sampleFormat.format(voice.displayName), voice.name)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="voice_download">Download voice</string>
     <string name="voice_empty_title">No Voices</string>
     <string name="voice_empty_description">No voices that match your language and region settings are installed.</string>
+    <string name="voice_preview_sample">Hello, this is Vocable, %1$s.</string>
 
     <!-- Settings -> Voice -->
     <string name="voice_settings_title">Voice</string>

--- a/app/src/test/java/com/willowtree/vocable/core/VocableTextToSpeechTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/core/VocableTextToSpeechTest.kt
@@ -1,6 +1,7 @@
 package com.willowtree.vocable.core
 
 import android.speech.tts.TextToSpeech
+import com.willowtree.vocable.core.VocableTextToSpeech.VoiceLabelInput
 import com.willowtree.vocable.core.VocableTextToSpeech.VoiceResolution
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -88,5 +89,51 @@ class VocableTextToSpeechTest {
                 features = setOf(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)
             )
         )
+    }
+
+    // #643: Android's TTS `Voice` has no human-friendly name, so each voice is labeled by locale
+    // plus an ordinal within that locale instead of a quality word — avoids interpolating an
+    // en-dash-containing label into a spoken preview sample.
+
+    @Test
+    fun `single voice for a locale is numbered Voice 1`() {
+        val result = VocableTextToSpeech.buildVoiceDisplayNames(
+            listOf(VoiceLabelInput("voice_a", "English (United States)", quality = 400))
+        )
+
+        assertEquals(mapOf("voice_a" to "English (United States) Voice 1"), result)
+    }
+
+    @Test
+    fun `voices sharing a locale are numbered by quality descending, then name`() {
+        val result = VocableTextToSpeech.buildVoiceDisplayNames(
+            listOf(
+                VoiceLabelInput("voice_low", "English (United States)", quality = 200),
+                VoiceLabelInput("voice_high", "English (United States)", quality = 500),
+                VoiceLabelInput("voice_mid", "English (United States)", quality = 300)
+            )
+        )
+
+        assertEquals(
+            mapOf(
+                "voice_high" to "English (United States) Voice 1",
+                "voice_mid" to "English (United States) Voice 2",
+                "voice_low" to "English (United States) Voice 3"
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `voices in different locales are numbered independently`() {
+        val result = VocableTextToSpeech.buildVoiceDisplayNames(
+            listOf(
+                VoiceLabelInput("voice_us", "English (United States)", quality = 400),
+                VoiceLabelInput("voice_gb", "English (United Kingdom)", quality = 400)
+            )
+        )
+
+        assertEquals("English (United States) Voice 1", result.getValue("voice_us"))
+        assertEquals("English (United Kingdom) Voice 1", result.getValue("voice_gb"))
     }
 }

--- a/app/src/test/java/com/willowtree/vocable/voiceselection/VoiceSelectionViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/voiceselection/VoiceSelectionViewModelTest.kt
@@ -27,7 +27,8 @@ class VoiceSelectionViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
-    private val voice = VocableTextToSpeech.VoiceOption("voice_1", "English (United States) – Enhanced", Locale.US)
+    private val voice = VocableTextToSpeech.VoiceOption("voice_1", "English (United States) Voice 1", Locale.US)
+    private val sampleFormat = "Hello, this is Vocable, %1\$s."
 
     private fun createViewModel(
         prefs: FakeVocableSharedPreferences = FakeVocableSharedPreferences()
@@ -142,7 +143,7 @@ class VoiceSelectionViewModelTest {
     fun `onPreviewVoice marks the voice as previewing`() = runTest {
         val (viewModel, _) = createViewModel()
 
-        viewModel.onPreviewVoice(voice)
+        viewModel.onPreviewVoice(voice, sampleFormat)
 
         assertEquals(voice.name, viewModel.uiState.value.previewingVoiceName)
     }
@@ -151,8 +152,8 @@ class VoiceSelectionViewModelTest {
     fun `onPreviewVoice again for the same voice stops the preview`() = runTest {
         val (viewModel, _) = createViewModel()
 
-        viewModel.onPreviewVoice(voice)
-        viewModel.onPreviewVoice(voice)
+        viewModel.onPreviewVoice(voice, sampleFormat)
+        viewModel.onPreviewVoice(voice, sampleFormat)
 
         assertNull(viewModel.uiState.value.previewingVoiceName)
     }


### PR DESCRIPTION
## Summary
- Preview now speaks a fixed `voice_preview_sample` phrase with the voice's display name interpolated, instead of speaking the display name itself
- Replaced the quality-word display name (`"English (United States) – Enhanced"`, whose en-dash is mis-spoken by many TTS engines) with a per-locale ordinal label (`"English (United States) Voice 1"`, `"Voice 2"`, ...), since Android's TTS API has no human-friendly voice name
- `getActiveVoiceDisplayName` now sources its label from the same numbering as the picker list, so the Settings → Voice active-voice text stays consistent

## Ticket
Part of #613 — closes #643

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Tests
- [ ] CI/CD
- [ ] Documentation

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist
- [x] Tests pass locally (`./gradlew testDebug`)
- [x] No API keys or secrets in code
- [ ] CLAUDE.md updated (if new pattern introduced)

## Notes
- Final sample-phrase wording is a pending product decision (see comment on #643) — implementation proceeds against the placeholder `"Hello, this is Vocable, %1$s."` per the ticket's own out-of-scope note
- `SettingsVoiceViewModel.onPreviewActiveVoice` (a different, already-shipped screen from #635) speaks `activeVoiceDisplayName` directly and benefits from the en-dash fix as a side effect, but wasn't otherwise touched — out of scope here