### PR TITLE
Remove the old Voice entry point from Selection Mode

### DIFF
--- a/Documentation/work-log/637-remove-voice-selection-mode-entry.md
+++ b/Documentation/work-log/637-remove-voice-selection-mode-entry.md
@@ -1,0 +1,24 @@
+# Remove the old Voice entry point from Selection Mode
+
+**Issue:** #637 (Part of #613)
+
+## What was needed
+
+Voice moved to Settings root (#635: Settings → Voice → Change Voice), but `SelectionModeScreen` still had its own live Voice row (`SettingsButton` + `onVoiceSelection`), and `SelectionModeViewModel` still maintained `selectedVoiceLabel` state to feed it. Left in place, that meant two reachable entry points to the same picker. This mirrors the Language-row removal already done on this same screen in #630/#631.
+
+## What changed
+
+- `SelectionModeScreen.kt`: removed the Voice `SettingsButton` row, its `voiceButtonRef` `ConstraintLayout` anchor, the `onVoiceSelection` callback param (on both `SelectionModeScreen` and `SelectionModeContent`), and the `selectedVoiceLabel` state collection. The `ON_RESUME` `DisposableEffect` that only existed to call `refreshLabels()` was removed entirely — `headTrackingEnabled` is already reactive via `asFlow()`/`collectAsStateWithLifecycle`, so nothing else needed it.
+- `SelectionModeViewModel.kt`: removed `selectedVoiceLabel`/`refreshLabels()`/`DEFAULT_VOICE_LABEL`. This was the *only* thing `IVocableSharedPreferences` was used for in this ViewModel, so the constructor param was dropped too rather than left unused.
+- `AppKoinModule.kt`: updated the `SelectionModeViewModel` factory to match the one-arg constructor.
+- `VocableNavHost.kt`: removed the `onVoiceSelection = { navController.navigate(ROUTE_VOICE_SELECTION) }` wiring on `SelectionModeScreen`'s composable. `ROUTE_VOICE_SELECTION` itself stays — Settings → Voice still navigates there per #635.
+- `strings.xml`: removed `settings_voice` (`"Voice\n%1$s"`), which had no other callers.
+- Updated `SelectionModeViewModelTest.kt` for the one-arg constructor; no other test coverage referenced the removed state, so nothing else needed changing.
+
+No layout-gap fix was needed for the "renders correctly with just Head Tracking" AC — Head Tracking was already the row directly above Voice with nothing anchored below Voice, so removing the last row in the `ConstraintLayout` left no dangling constraints.
+
+## Pointers
+
+- Issue: #637 · Parent: #613
+- Precedent: #630/#631 (Language row removal from this same screen)
+- Related: #635 (Settings root Voice row / Settings → Voice, the replacement entry point)

--- a/app/src/main/java/com/willowtree/vocable/di/AppKoinModule.kt
+++ b/app/src/main/java/com/willowtree/vocable/di/AppKoinModule.kt
@@ -82,7 +82,7 @@ val vocableKoinModule = module {
 
         scoped { FaceTrackingManager(get(), get()) }
         viewModel { FaceTrackingViewModel(get()) }
-        viewModel { SelectionModeViewModel(get(), get()) }
+        viewModel { SelectionModeViewModel(get()) }
     }
 
     factory<IFaceTrackingPermissions> {

--- a/app/src/main/java/com/willowtree/vocable/ui/VocableNavHost.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/VocableNavHost.kt
@@ -227,7 +227,6 @@ fun VocableNavHost(
             val vm: SelectionModeViewModel = mainActivity.getViewModel()
             SelectionModeScreen(
                 onBack = { navController.popBackStack(ROUTE_SETTINGS, false) },
-                onVoiceSelection = { navController.navigate(ROUTE_VOICE_SELECTION) },
                 viewModel = vm
             )
         }

--- a/app/src/main/java/com/willowtree/vocable/ui/selectionmode/SelectionModeScreen.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/selectionmode/SelectionModeScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,14 +23,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.asFlow
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.willowtree.vocable.R
 import com.willowtree.vocable.ui.components.GazeButton
-import com.willowtree.vocable.ui.settings.SettingsButton
 import com.willowtree.vocable.ui.theme.ColorPrimary
 import com.willowtree.vocable.ui.theme.ColorPrimaryDark
 import com.willowtree.vocable.ui.theme.SelectedColor
@@ -42,28 +37,13 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 fun SelectionModeScreen(
     onBack: () -> Unit,
-    onVoiceSelection: () -> Unit,
     viewModel: SelectionModeViewModel = koinViewModel()
 ) {
     val enabled by viewModel.headTrackingEnabled.asFlow().collectAsStateWithLifecycle(initialValue = false)
-    val selectedVoiceLabel by viewModel.selectedVoiceLabel.collectAsStateWithLifecycle()
-
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) {
-                viewModel.refreshLabels()
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
 
     SelectionModeContent(
         enabled = enabled,
-        selectedVoiceLabel = selectedVoiceLabel,
         onBack = onBack,
-        onVoiceSelection = onVoiceSelection,
         onToggleHeadTracking = {
             if (!enabled) {
                 viewModel.requestHeadTracking()
@@ -77,9 +57,7 @@ fun SelectionModeScreen(
 @Composable
 fun SelectionModeContent(
     enabled: Boolean,
-    selectedVoiceLabel: String,
     onBack: () -> Unit,
-    onVoiceSelection: () -> Unit,
     onToggleHeadTracking: () -> Unit
 ) {
     val buttonHeight = dimensionResource(id = R.dimen.selection_mode_button_height)
@@ -89,7 +67,7 @@ fun SelectionModeContent(
             .fillMaxSize()
             .padding(dimensionResource(id = R.dimen.settings_margin_default))
     ) {
-        val (titleRef, backButtonRef, trackingButtonRef, voiceButtonRef) = createRefs()
+        val (titleRef, backButtonRef, trackingButtonRef) = createRefs()
         val backButtonSize = dimensionResource(id = R.dimen.settings_close_button_width)
 
         Text(
@@ -167,19 +145,6 @@ fun SelectionModeContent(
                 )
             }
         }
-
-        SettingsButton(
-            text = stringResource(R.string.settings_voice, selectedVoiceLabel),
-            onClick = onVoiceSelection,
-            modifier = Modifier
-                .height(buttonHeight)
-                .fillMaxWidth()
-                .constrainAs(voiceButtonRef) {
-                    top.linkTo(trackingButtonRef.bottom, margin = 16.dp)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                }
-        )
     }
 }
 
@@ -189,9 +154,7 @@ fun SelectionModeScreenPreview() {
     VocableTheme {
         SelectionModeContent(
             enabled = true,
-            selectedVoiceLabel = "Default",
             onBack = {},
-            onVoiceSelection = {},
             onToggleHeadTracking = {}
         )
     }

--- a/app/src/main/java/com/willowtree/vocable/ui/selectionmode/SelectionModeViewModel.kt
+++ b/app/src/main/java/com/willowtree/vocable/ui/selectionmode/SelectionModeViewModel.kt
@@ -4,28 +4,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.map
 import com.willowtree.vocable.core.IFaceTrackingPermissions
-import com.willowtree.vocable.core.IVocableSharedPreferences
 import com.willowtree.vocable.core.isEnabled
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
 /** ViewModel for the Selection Mode screen. */
 class SelectionModeViewModel(
-    private val faceTrackingPermissions: IFaceTrackingPermissions,
-    private val sharedPreferences: IVocableSharedPreferences
+    private val faceTrackingPermissions: IFaceTrackingPermissions
 ) : ViewModel() {
 
     val headTrackingEnabled = faceTrackingPermissions.permissionState.asLiveData().map { it.isEnabled() }
-
-    private val _selectedVoiceLabel = MutableStateFlow(
-        sharedPreferences.getSelectedVoiceName() ?: DEFAULT_VOICE_LABEL
-    )
-    val selectedVoiceLabel: StateFlow<String> = _selectedVoiceLabel.asStateFlow()
-
-    fun refreshLabels() {
-        _selectedVoiceLabel.value = sharedPreferences.getSelectedVoiceName() ?: DEFAULT_VOICE_LABEL
-    }
 
     fun requestHeadTracking() {
         faceTrackingPermissions.requestFaceTracking()
@@ -33,9 +19,5 @@ class SelectionModeViewModel(
 
     fun disableHeadTracking() {
         faceTrackingPermissions.disableFaceTracking()
-    }
-
-    companion object {
-        const val DEFAULT_VOICE_LABEL = "Default"
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,6 @@
     <string name="settings_dialog_message">You\'re about to be taken outside the app. You may lose head tracking control.</string>
     <string name="settings_dialog_continue">Continue</string>
     <string name="settings_dialog_cancel">Cancel</string>
-    <string name="settings_voice">Voice\n%1$s</string>
 
     <!-- Settings Options -->
     <string name="settings_edit_saying">My Sayings</string>

--- a/app/src/test/java/com/willowtree/vocable/settings/selectionmode/SelectionModeViewModelTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/settings/selectionmode/SelectionModeViewModelTest.kt
@@ -5,7 +5,6 @@ import com.willowtree.vocable.MainDispatcherRule
 import com.willowtree.vocable.getOrAwaitValue
 import com.willowtree.vocable.ui.selectionmode.SelectionModeViewModel
 import com.willowtree.vocable.utils.FakeFaceTrackingPermissions
-import com.willowtree.vocable.utils.FakeVocableSharedPreferences
 import com.willowtree.vocable.core.IFaceTrackingPermissions
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
@@ -22,7 +21,7 @@ class SelectionModeViewModelTest {
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     private fun createViewModel(permissions: IFaceTrackingPermissions): SelectionModeViewModel {
-        return SelectionModeViewModel(permissions, FakeVocableSharedPreferences())
+        return SelectionModeViewModel(permissions)
     }
 
     private fun createTrackingPermissions(headTrackingEnabled: Boolean): FakeFaceTrackingPermissions {


### PR DESCRIPTION
## Summary
- Removed the Voice row (`SettingsButton`), its `ConstraintLayout` anchor, and the `onVoiceSelection` callback from `SelectionModeScreen`/`SelectionModeContent`
- Removed `selectedVoiceLabel`/`refreshLabels()`/`DEFAULT_VOICE_LABEL` from `SelectionModeViewModel`; dropped the now-unused `IVocableSharedPreferences` constructor param since that was its only use there (updated `AppKoinModule` and the test)
- Removed the `onVoiceSelection` wiring on `SelectionModeScreen` in `VocableNavHost.kt` — `ROUTE_VOICE_SELECTION` itself stays, since Settings → Voice still navigates there per #635
- Removed the now-orphaned `settings_voice` string resource
- Added `Documentation/work-log/637-remove-voice-selection-mode-entry.md`

## Ticket
Part of #613 — closes #637

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Tests
- [ ] CI/CD
- [ ] Documentation

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist
- [x] Tests pass locally (`./gradlew testDebug`)
- [x] No API keys or secrets in code
- [ ] CLAUDE.md updated (if new pattern introduced)

## Notes
- Mirrors the Language-row removal already done on this same screen in #630/#631
- Selection Mode renders correctly with just Head Tracking after removal — no layout gap, since Voice was the last row with nothing anchored below it