### PR TITLE
create-ticket: auto-add issues to Project #50 and link sub-issue parents

### DIFF
--- a/.claude/skills/create-ticket/SKILL.md
+++ b/.claude/skills/create-ticket/SKILL.md
@@ -45,4 +45,66 @@ Do not add: day-by-day plans, "resolved decisions" / "decisions still needed" ta
 
 Once the body is drafted and passes the scope-creep guard, create it with `gh issue create -R willowtreeapps/vocable-android --title "<title>" --body "<drafted body>"`.
 
-After creating, this is the point where the "Starting new work" workflow in `CLAUDE.md` continues: branch as `feature/<issue-number>/<short-description>`, PR against the right integration branch using `.github/PULL_REQUEST_TEMPLATE.md`, and a `Documentation/work-log/<issue-number>-<slug>.md` entry once the work is done.
+## Adding it to the board
+
+Every issue this skill creates also gets added to [Project #50](https://github.com/orgs/willowtreeapps/projects/50/views/1) with Status **"Pre Backlog"** — don't leave a newly-created issue off the board; it's invisible to triage/prioritization until it's on it.
+
+The `gh` token needs the `project` scope for this (not just `read:project`) — if the mutation below fails with `INSUFFICIENT_SCOPES`, run `gh auth refresh -s project` (an interactive device-flow approval) before retrying.
+
+1. **Get the issue's node ID** (from the `gh issue create` output URL, or query it):
+   ```bash
+   gh api graphql -f query='
+   query { repository(owner: "willowtreeapps", name: "vocable-android") {
+     issue(number: <N>) { id }
+   } }'
+   ```
+2. **Add it to the project** (project node ID `PVT_kwDOAAiCcM4AiZ3r` — Project #50 on `willowtreeapps`):
+   ```bash
+   gh api graphql -f query='
+   mutation($projectId: ID!, $contentId: ID!) {
+     addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+       item { id }
+     }
+   }' -f projectId="PVT_kwDOAAiCcM4AiZ3r" -f contentId="<issue node id>"
+   ```
+   Note the returned `item.id` — that's the **project item ID**, different from the issue's node ID, and what the next step needs.
+3. **Set Status to "Pre Backlog"** (Status field ID `PVTSSF_lADOAAiCcM4AiZ3rzga7WAg`, "Pre Backlog" option ID `77e56e59`):
+   ```bash
+   gh api graphql -f query='
+   mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+     updateProjectV2ItemFieldValue(input: {
+       projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+       value: { singleSelectOptionId: $optionId }
+     }) { projectV2Item { id } }
+   }' -f projectId="PVT_kwDOAAiCcM4AiZ3r" -f itemId="<project item id from step 2>" \
+      -f fieldId="PVTSSF_lADOAAiCcM4AiZ3rzga7WAg" -f optionId="77e56e59"
+   ```
+
+If the project's fields/options ever change, re-derive the IDs rather than trust the ones above indefinitely:
+```bash
+gh api graphql -f query='
+query { organization(login: "willowtreeapps") { projectV2(number: 50) {
+  id fields(first: 20) { nodes {
+    ... on ProjectV2FieldCommon { id name }
+    ... on ProjectV2SingleSelectField { id name options { id name } }
+  } }
+} } }'
+```
+
+## Linking sub-issues to their parent
+
+If the ticket has a `Part of #<parent>` line, also link it via GitHub's **native sub-issue relationship** (not just the text reference) — this is what populates the parent issue's "Sub-issues progress" and this issue's "Parent issue" fields on the project board automatically; there's no separate project-field mutation for it.
+
+```bash
+gh api graphql -f query='
+mutation($issueId: ID!, $subIssueId: ID!) {
+  addSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) {
+    issue { number }
+    subIssue { number }
+  }
+}' -f issueId="<parent issue node id>" -f subIssueId="<new issue node id>"
+```
+
+Get each node ID the same way as step 1 above (`repository(...).issue(number: N).id`). Skip this step entirely for standalone issues (no `Part of #<parent>` line).
+
+After creating and linking, this is the point where the "Starting new work" workflow in `CLAUDE.md` continues: branch as `feature/<issue-number>/<short-description>`, PR against the right integration branch using `.github/PULL_REQUEST_TEMPLATE.md`, and a `Documentation/work-log/<issue-number>-<slug>.md` entry once the work is done.

--- a/.claude/skills/create-ticket/SKILL.md
+++ b/.claude/skills/create-ticket/SKILL.md
@@ -47,16 +47,38 @@ Once the body is drafted and passes the scope-creep guard, create it with `gh is
 
 ## Creating and linking the branch
 
-Create the working branch through the issue's own **"Development"** link
-(`createLinkedBranch`), not a plain `git checkout -b` — this makes the branch
-show up under the issue's Development section on GitHub from the moment work
-starts, not only once a PR eventually exists.
+**For sub-issue tickets whose PR will target a parent integration branch
+(e.g. `feature/voice-selection`) — which is the normal case per `CLAUDE.md`'s
+sub-issue convention — `createLinkedBranch` is the ONLY way to get anything
+to show under the issue's "Development" section, not merely the preferred
+way.** Confirmed live and worth being precise about, since it's easy to
+assume the usual `Closes #N` trick covers this and it does not:
 
-This needs **write access to the repo** — same requirement as pushing a
-branch or opening a PR. If it fails with `FORBIDDEN: does not have the
-correct permissions`, that's a repo-access gap, not a scope/token problem
-(confirmed live: this is a distinct failure from the `INSUFFICIENT_SCOPES`
-case above).
+- A `Closes #653`/`Closes #654` reference in a PR body targeting
+  `feature/voice-selection` did **not** register as a closing reference at
+  all — `closingIssuesReferences` came back empty on both the issue side and
+  the PR side, and the timeline's `CROSS_REFERENCED_EVENT` explicitly reports
+  `willCloseTarget: false`. This isn't just "won't auto-close on merge" (the
+  already-documented caveat above) — the reference is never linked as
+  "Development" material in the first place when the PR's base isn't the
+  repo's default branch.
+- There is **no GraphQL mutation to manually link an already-existing PR or
+  branch** to an issue's Development section — only `createLinkedBranch`
+  (which creates a brand-new ref) and `deleteLinkedBranch` exist. If a branch
+  with the intended name was already pushed via plain `git push` (not through
+  this mutation), there is no way to retroactively attach it — the name is
+  already taken, and `createLinkedBranch` only creates, it doesn't adopt.
+
+**Practical takeaway: call `createLinkedBranch` FIRST, before any branch
+with that name exists anywhere** — as part of ticket creation, right after
+`gh issue create`, not as an optional nicety alongside a manually-pushed
+branch. If you skip this step and push a plain branch first (as happened
+with #653/#654 before this gap was found), the ticket's Development section
+will stay empty even after the PR is opened and merged — the only fix at
+that point is deleting the already-pushed branch/PR and recreating it via
+this mutation, which is a real enough disruption (an open PR pointing at a
+now-deleted branch) that it's a judgment call for whoever hits it, not
+something to do automatically.
 
 1. Get the issue's node ID (same query as "Adding it to the board" step 1),
    the repository's node ID, and the base commit to branch from (the tip of
@@ -67,7 +89,11 @@ case above).
    gh api repos/willowtreeapps/vocable-android --jq '.node_id'
    ```
 2. Create + link the branch in one call (name follows the usual
-   `feature/<issue-number>/<short-description>` convention):
+   `feature/<issue-number>/<short-description>` convention) — this needs
+   **write access to the repo** (same requirement as pushing/opening a PR;
+   fails with `FORBIDDEN: does not have the correct permissions` if missing,
+   a distinct failure from the `project`-scope `INSUFFICIENT_SCOPES` case
+   above):
    ```bash
    gh api graphql -f query='
    mutation($issueId: ID!, $oid: GitObjectID!, $name: String!, $repositoryId: ID!) {
@@ -84,10 +110,11 @@ case above).
    git checkout feature/<issue-number>/<short-description>
    ```
 
-If a PR is opened later with a `Closes #N`/`Fixes #N` reference in its body,
-GitHub links that PR under Development automatically too — no extra action
-needed for that case; `createLinkedBranch` is specifically for making the
-*branch itself* visible under Development before a PR exists.
+A standalone issue whose PR will target `main` (the repo's default branch)
+doesn't have this problem — `Closes #N` links and auto-closes normally there
+— but every sub-issue in this repo's actual workflow targets a parent
+integration branch, so treat `createLinkedBranch`-first as the default, not
+the exception.
 
 ## Adding it to the board
 

--- a/.claude/skills/create-ticket/SKILL.md
+++ b/.claude/skills/create-ticket/SKILL.md
@@ -45,6 +45,50 @@ Do not add: day-by-day plans, "resolved decisions" / "decisions still needed" ta
 
 Once the body is drafted and passes the scope-creep guard, create it with `gh issue create -R willowtreeapps/vocable-android --title "<title>" --body "<drafted body>"`.
 
+## Creating and linking the branch
+
+Create the working branch through the issue's own **"Development"** link
+(`createLinkedBranch`), not a plain `git checkout -b` — this makes the branch
+show up under the issue's Development section on GitHub from the moment work
+starts, not only once a PR eventually exists.
+
+This needs **write access to the repo** — same requirement as pushing a
+branch or opening a PR. If it fails with `FORBIDDEN: does not have the
+correct permissions`, that's a repo-access gap, not a scope/token problem
+(confirmed live: this is a distinct failure from the `INSUFFICIENT_SCOPES`
+case above).
+
+1. Get the issue's node ID (same query as "Adding it to the board" step 1),
+   the repository's node ID, and the base commit to branch from (the tip of
+   the parent's integration branch, e.g. `feature/voice-selection`, or `main`
+   for a standalone issue with no parent):
+   ```bash
+   git rev-parse origin/<base-branch>
+   gh api repos/willowtreeapps/vocable-android --jq '.node_id'
+   ```
+2. Create + link the branch in one call (name follows the usual
+   `feature/<issue-number>/<short-description>` convention):
+   ```bash
+   gh api graphql -f query='
+   mutation($issueId: ID!, $oid: GitObjectID!, $name: String!, $repositoryId: ID!) {
+     createLinkedBranch(input: {issueId: $issueId, oid: $oid, name: $name, repositoryId: $repositoryId}) {
+       linkedBranch { ref { name } }
+     }
+   }' -f issueId="<issue node id>" -f oid="<base commit SHA>" \
+      -f name="feature/<issue-number>/<short-description>" -f repositoryId="<repo node id>"
+   ```
+3. Fetch and check out the branch it just created, instead of creating a new
+   local one:
+   ```bash
+   git fetch origin feature/<issue-number>/<short-description>
+   git checkout feature/<issue-number>/<short-description>
+   ```
+
+If a PR is opened later with a `Closes #N`/`Fixes #N` reference in its body,
+GitHub links that PR under Development automatically too — no extra action
+needed for that case; `createLinkedBranch` is specifically for making the
+*branch itself* visible under Development before a PR exists.
+
 ## Adding it to the board
 
 Every issue this skill creates also gets added to [Project #50](https://github.com/orgs/willowtreeapps/projects/50/views/1) with Status **"Pre Backlog"** — don't leave a newly-created issue off the board; it's invisible to triage/prioritization until it's on it.
@@ -78,6 +122,22 @@ The `gh` token needs the `project` scope for this (not just `read:project`) — 
      }) { projectV2Item { id } }
    }' -f projectId="PVT_kwDOAAiCcM4AiZ3r" -f itemId="<project item id from step 2>" \
       -f fieldId="PVTSSF_lADOAAiCcM4AiZ3rzga7WAg" -f optionId="77e56e59"
+   ```
+4. **Move it to the top of its column** — new tickets should sort first in
+   the board's grouped-by-Status view, not get buried at the bottom.
+   `updateProjectV2ItemPosition` orders items on a single project-wide list;
+   omitting `afterId` moves an item to the very front of that list, which is
+   sufficient to put it first within its own Status group too (nothing
+   precedes it at all, so it's necessarily first among items sharing its
+   status). Confirmed live: this does not disturb other items' relative
+   order, only shifts the moved item ahead of everything.
+   ```bash
+   gh api graphql -f query='
+   mutation($projectId: ID!, $itemId: ID!) {
+     updateProjectV2ItemPosition(input: {projectId: $projectId, itemId: $itemId}) {
+       clientMutationId
+     }
+   }' -f projectId="PVT_kwDOAAiCcM4AiZ3r" -f itemId="<project item id from step 2>"
    ```
 
 If the project's fields/options ever change, re-derive the IDs rather than trust the ones above indefinitely:

--- a/Documentation/work-log/654-create-ticket-project-autolink.md
+++ b/Documentation/work-log/654-create-ticket-project-autolink.md
@@ -1,0 +1,63 @@
+# #654 — create-ticket: auto-add issues to Project #50 and link sub-issue parents
+
+## What
+
+Updated `.claude/skills/create-ticket/SKILL.md` so that after `gh issue create`,
+the new issue is also:
+1. Added to [Project #50](https://github.com/orgs/willowtreeapps/projects/50)
+   with Status set to **"Pre Backlog"**.
+2. If it has a `Part of #<parent>` line, linked to that parent via GitHub's
+   native sub-issue relationship (`addSubIssue`), not just the text reference.
+
+## Why
+
+Tickets created via `/create-ticket` previously existed only as GitHub issues
+until someone manually added them to the board — invisible to triage until
+that happened. Sub-issues also weren't linked via GitHub's native
+parent/sub-issue relationship, so the project board's "Parent issue"/
+"Sub-issues progress" fields stayed empty even when the ticket body said
+`Part of #N` in prose.
+
+## Key decisions
+
+**Project field mutation vs. native sub-issue relationship — these are two
+different mechanisms, not one.** Setting Status is a project-field mutation
+(`updateProjectV2ItemFieldValue`, scoped to one project). Linking a sub-issue
+to its parent is a **repo-level relationship** (`addSubIssue`, via `Issue.parent`/
+`Issue.subIssues`) that the project's "Parent issue"/"Sub-issues progress"
+fields merely *reflect* — there is no project-field mutation for parent
+linkage; the project fields are read-only projections of the repo-level
+relationship. `SKILL.md` documents both, in the right place for each.
+
+**Requires the `project` OAuth scope**, not just `read:project` — the write
+mutations (`addProjectV2ItemById`, `updateProjectV2ItemFieldValue`) fail with
+`INSUFFICIENT_SCOPES` on a read-only token. Documented the `gh auth refresh -s
+project` fix inline so it isn't a surprise mid-task.
+
+**IDs are hardcoded in the doc (project/field/option IDs), with an escape
+hatch.** These don't change often, but `SKILL.md` includes the introspection
+query to re-derive them if the project's fields/options are ever edited,
+rather than leaving future-Claude to guess or break silently.
+
+## Verification
+
+- Confirmed `Issue.parent`/`Issue.subIssues`/`Mutation.addSubIssue` exist via
+  GraphQL introspection (this repo's schema does support native sub-issues).
+- Confirmed the **read side is already real, not hypothetical**: issue #630
+  already carries a live `parent` link to #613 in this repo — so the
+  underlying relationship is genuinely in use here, not a feature nobody's
+  touched.
+- Did **not** fabricate a test parent/child link on real issues just to
+  exercise `addSubIssue` — the read-side confirmation above gives high
+  confidence in the mutation shape (matches the introspected input fields
+  exactly: `issueId`, `subIssueId`) without polluting real issue timelines.
+  The next real sub-issue created via this skill is the first live exercise
+  of the write path — check its result once that happens.
+- **Did** live-verify the project-add + Status-set steps for real, by
+  dogfooding them against issue #654 itself (this ticket): added to
+  Project #50, Status confirmed as "Pre Backlog" via a follow-up query.
+
+## Links
+
+- Issue: #654
+- Project: https://github.com/orgs/willowtreeapps/projects/50/views/1

--- a/Documentation/work-log/654-create-ticket-project-autolink.md
+++ b/Documentation/work-log/654-create-ticket-project-autolink.md
@@ -6,8 +6,14 @@ Updated `.claude/skills/create-ticket/SKILL.md` so that after `gh issue create`,
 the new issue is also:
 1. Added to [Project #50](https://github.com/orgs/willowtreeapps/projects/50)
    with Status set to **"Pre Backlog"**.
-2. If it has a `Part of #<parent>` line, linked to that parent via GitHub's
+2. Moved to the top of its Status column (`updateProjectV2ItemPosition`,
+   `afterId` omitted) instead of landing wherever the API defaults it.
+3. If it has a `Part of #<parent>` line, linked to that parent via GitHub's
    native sub-issue relationship (`addSubIssue`), not just the text reference.
+4. Given a working branch via `createLinkedBranch` (issue's native
+   "Development" link) instead of a plain `git checkout -b`, so the branch
+   shows up under the issue's Development section from the start of work,
+   not only once a PR eventually exists.
 
 ## Why
 
@@ -29,6 +35,15 @@ fields merely *reflect* — there is no project-field mutation for parent
 linkage; the project fields are read-only projections of the repo-level
 relationship. `SKILL.md` documents both, in the right place for each.
 
+**Column position is a side effect of a project-wide order, not a per-column
+one.** `updateProjectV2ItemPosition` orders items on a single flat list for
+the whole project; there's no separate "position within this Status group"
+concept in the API. Moving an item to the front of that flat list
+(`afterId` omitted) is sufficient to make it first within its own Status
+group too, since nothing at all precedes it — confirmed live (see below) that
+this doesn't reorder other items relative to each other, it just shifts the
+moved item ahead of everything.
+
 **Requires the `project` OAuth scope**, not just `read:project` — the write
 mutations (`addProjectV2ItemById`, `updateProjectV2ItemFieldValue`) fail with
 `INSUFFICIENT_SCOPES` on a read-only token. Documented the `gh auth refresh -s
@@ -38,6 +53,17 @@ project` fix inline so it isn't a surprise mid-task.
 hatch.** These don't change often, but `SKILL.md` includes the introspection
 query to re-derive them if the project's fields/options are ever edited,
 rather than leaving future-Claude to guess or break silently.
+
+**`createLinkedBranch` needs repo write access, distinct from the `project`
+scope issue above.** Tested live against issue #654 with the current token
+(which already has `project`/`repo`/`read:org` scopes) and got `FORBIDDEN:
+rhyslutsky does not have the correct permissions to execute
+CreateLinkedBranch` — a different failure mode than `INSUFFICIENT_SCOPES`,
+confirming it's a repo-collaborator-access gap, not a token-scope gap (the
+same gap already blocking `git push`/PR creation on #653). `SKILL.md` calls
+this out explicitly so the two failure modes aren't confused with each other.
+Once write access exists, this step should just work — nothing else about it
+needs to change.
 
 ## Verification
 

--- a/Documentation/work-log/654-create-ticket-project-autolink.md
+++ b/Documentation/work-log/654-create-ticket-project-autolink.md
@@ -62,8 +62,31 @@ CreateLinkedBranch` — a different failure mode than `INSUFFICIENT_SCOPES`,
 confirming it's a repo-collaborator-access gap, not a token-scope gap (the
 same gap already blocking `git push`/PR creation on #653). `SKILL.md` calls
 this out explicitly so the two failure modes aren't confused with each other.
-Once write access exists, this step should just work — nothing else about it
-needs to change.
+Write access landed later in the same session; see below for what that
+revealed.
+
+**Bigger finding, discovered only after write access arrived: `Closes #N`
+does NOT link a PR under "Development" at all when the PR targets a
+non-default branch — not just "won't auto-close," genuinely not linked.**
+Once PRs #655/#656 were opened (bodies containing `Closes #653`/`Closes
+#654`, both targeting `feature/voice-selection` per this repo's sub-issue
+convention), I checked `closingIssuesReferences` on both the issue and PR
+sides via the API: **empty on both**, and the timeline's
+`CROSS_REFERENCED_EVENT` explicitly reports `willCloseTarget: false`. This is
+a stronger statement than the already-known "closes #N won't auto-fire on
+merge" caveat — the reference is never registered as Development material in
+the first place. There's also no mutation to manually link an
+already-existing PR/branch (only `createLinkedBranch`, create-only, and
+`deleteLinkedBranch`) — so a branch already pushed via plain `git push`, like
+#653/#654's were, can't be retroactively linked without deleting and
+recreating it. `SKILL.md` now states plainly that `createLinkedBranch` must
+run FIRST, before any branch of that name exists anywhere, for every
+sub-issue ticket in this repo (which is the normal case, not an edge case,
+per the sub-issue convention) — not merely "preferred," as I'd first written
+it. Left #653/#654 themselves as-is (their Development sections are empty)
+rather than delete+recreate already-open branches/PRs just for this —
+flagged as a judgment call for whoever's driving those tickets, not something
+to force through automatically.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- Updates `.claude/skills/create-ticket/SKILL.md` so newly-created tickets no longer sit invisible off the project board:
  - Added to Project #50 with Status **"Pre Backlog"**.
  - Moved to the top of that Status column (`updateProjectV2ItemPosition`, `afterId` omitted).
  - `Part of #<parent>` tickets get linked to their parent via GitHub's native sub-issue relationship (`addSubIssue`), not just the prose reference.
  - Documents `createLinkedBranch` for creating the working branch through the issue's own Development link, so the branch (not just an eventual PR) shows up there from the start of work.
- Live-verified against real data: dogfooded the project-add + Status-set steps on issue #654 itself, and confirmed issue #630 already carries a real native `parent` link to #613 in this repo (so the underlying GitHub feature is genuinely in use here, not hypothetical).

## Ticket
Closes #654 — same non-default-branch caveat as #653/PR #655: will manually close after merge since `closes #N` won't auto-fire against `feature/voice-selection`.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation
- [ ] Refactor
- [ ] Tests
- [ ] CI/CD

## Testing
- [ ] Unit tests added/updated — N/A, this is a skill doc, not app code
- [ ] Integration tests added/updated — N/A, same reason
- [x] Manual testing performed — see `Documentation/work-log/654-create-ticket-project-autolink.md` for the full verification writeup, including the one gap found: `createLinkedBranch` needs repo write access distinct from the `project` scope (confirmed live via a `FORBIDDEN` response before this PR's write access was granted)

## Checklist
- [ ] Tests pass locally (`./gradlew testDebug`) — N/A, no app code (`app/`) touched
- [x] No API keys or secrets in code — all mutations shell out to `gh api graphql`, reusing the machine's existing `gh auth login`
- [ ] CLAUDE.md updated (if new pattern introduced) — not updated; doesn't introduce an app-development pattern

See `Documentation/work-log/654-create-ticket-project-autolink.md` for the complete writeup.
