### PR TITLE
Source versionCode from Play Console instead of per-workflow run_number

### DIFF
--- a/.github/workflows/pre-release-upload.yml
+++ b/.github/workflows/pre-release-upload.yml
@@ -27,9 +27,24 @@ jobs:
           ENCODED_RELEASE_KEYSTORE: ${{ secrets.ENCODED_RELEASE_KEYSTORE }}
         run: echo $ENCODED_RELEASE_KEYSTORE | base64 -d > keystore
 
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
+        run: echo $GOOGLE_SERVICES_JSON_B64 | base64 -d > app/google-services.json
+
+      - name: Authenticate to Google Play
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.PLAY_STORE_CREDENTIALS }}
+
+      - name: Compute next versionCode
+        id: version_code
+        run: |
+          echo "value=$(./scripts/get-next-version-code.sh com.willowtree.vocable)" >> "$GITHUB_OUTPUT"
+
       - name: Build & Assemble Release APK
         env:
-          VERSION_CODE: ${{ github.run_number }}
+          VERSION_CODE: ${{ steps.version_code.outputs.value }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
         run: |

--- a/.github/workflows/ps-release.yml
+++ b/.github/workflows/ps-release.yml
@@ -40,9 +40,19 @@ jobs:
           ENCODED_RELEASE_KEYSTORE: ${{ secrets.ENCODED_RELEASE_KEYSTORE }}
         run: echo $ENCODED_RELEASE_KEYSTORE | base64 -d > keystore
 
+      - name: Authenticate to Google Play
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.PLAY_STORE_CREDENTIALS }}
+
+      - name: Compute next versionCode
+        id: version_code
+        run: |
+          echo "value=$(./scripts/get-next-version-code.sh com.willowtree.vocable)" >> "$GITHUB_OUTPUT"
+
       - name: Build & Assemble Release APK
         env:
-          VERSION_CODE: ${{ github.run_number }}
+          VERSION_CODE: ${{ steps.version_code.outputs.value }}
           VERSION_NAME: ${{ env.version_name }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}

--- a/scripts/get-next-version-code.sh
+++ b/scripts/get-next-version-code.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Prints the next Android versionCode for com.willowtree.vocable, computed as
+# (highest versionCode already published to any Play Store track) + 1.
+#
+# This exists because both release workflows used to derive versionCode from
+# `github.run_number`, which is scoped per-workflow-file — a workflow that has
+# never run (or runs rarely) starts its counter at 1, independent of how far
+# along a more frequently-run sibling workflow's counter is. That let a
+# lower/duplicate versionCode reach Play Store, which rejects any upload with
+# a versionCode <= one already used on any track. Querying Play directly for
+# ground truth removes the dependency on run history entirely.
+#
+# Requires: an active `gcloud` auth session for a service account with access
+# to the Play Developer API for this app (see google-github-actions/auth in
+# the calling workflow), and `curl`/`jq` on PATH.
+#
+# Usage: ./get-next-version-code.sh <package-name>
+
+set -euo pipefail
+
+PACKAGE_NAME="${1:?usage: get-next-version-code.sh <package-name>}"
+API_BASE="https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${PACKAGE_NAME}"
+
+ACCESS_TOKEN=$(gcloud auth print-access-token)
+
+EDIT_ID=$(curl -sS -X POST \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "${API_BASE}/edits" | jq -r '.id')
+
+if [[ -z "${EDIT_ID}" || "${EDIT_ID}" == "null" ]]; then
+  echo "Failed to create a Play Console edit for ${PACKAGE_NAME}" >&2
+  exit 1
+fi
+
+cleanup() {
+  curl -sS -X DELETE \
+    -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+    "${API_BASE}/edits/${EDIT_ID}" >/dev/null || true
+}
+trap cleanup EXIT
+
+TRACKS_JSON=$(curl -sS \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "${API_BASE}/edits/${EDIT_ID}/tracks")
+
+MAX_VERSION_CODE=$(echo "${TRACKS_JSON}" | jq '[.tracks[]?.releases[]?.versionCodes[]? | tonumber] | max // 0')
+
+echo $((MAX_VERSION_CODE + 1))


### PR DESCRIPTION
## Summary
- Source `versionCode` for both release workflows from the Play Developer API (highest versionCode already published across all tracks, +1) instead of `github.run_number`
- Add `scripts/get-next-version-code.sh`, which authenticates via the existing `PLAY_STORE_CREDENTIALS` service account and queries Play Console directly
- Wire the script into `ps-release.yml` and `pre-release-upload.yml` via a new `Authenticate to Google Play` + `Compute next versionCode` step pair

## Ticket
Part of #626 — closes #659

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Tests
- [x] CI/CD
- [ ] Documentation

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Manual testing: validated both workflow YAML files parse correctly, and verified the `jq` versionCode-extraction logic against sample Play Console track responses (populated tracks and empty-tracks edge case). Have not yet exercised the script against live Play credentials — that's covered by sibling issue #658 (end-to-end dry-run), which depends on this fix plus #657 and #660.

## Checklist
- [x] Tests pass locally (`./gradlew testDebug`)
- [x] No API keys or secrets in code
- [ ] CLAUDE.md updated (if new pattern introduced)
