### PR TITLE
throughput-forecast: breakdown by parent, exclude parent-container issues, daily Voice Selection report

### DIFF
--- a/.claude/scripts/forecast-html.py
+++ b/.claude/scripts/forecast-html.py
@@ -182,7 +182,8 @@ def main():
 
     # ---------- Overview panel ----------
     def build_overview():
-        cards = [
+        no_forecast = team.get("q1") is None or team.get("q2") is None
+        cards = [] if no_forecast else [
             dual_card("Clear the open queue",
                       f"{team['q1']['w50']}w", f"{team['q1']['w85']}w",
                       [f"{team['backlog']} items · 85% by <b>{esc(team['q1']['date85'])}</b>",
@@ -205,6 +206,13 @@ def main():
                           f"of {bands.get('total',0)} in flight"],
                           accent=ST_BREACH))
         cardhtml = f'<div class="cards">{"".join(cards)}</div>'
+
+        if no_forecast:
+            note = ('<div class="note">No complete throughput weeks fall inside this '
+                     f'window ({esc(m.get("window",""))}) — the delivery forecast (Q1/Q2) '
+                     'needs at least one full calendar week of Done items and can\'t be '
+                     'computed here. Showing cycle-time SLE and aging WIP only, below.</div>')
+            return cardhtml + note
 
         # Team throughput columns
         wk_labels = [f"w{i+1}" for i in range(len(team["sample"]))]

--- a/.claude/scripts/forecast.py
+++ b/.claude/scripts/forecast.py
@@ -646,7 +646,7 @@ def main():
     rng = random.Random(args.seed)
     done_statuses = [s.strip() for s in args.done_status.split(",")]
 
-    if args.throughput and not args.live:
+    if args.done or (args.throughput and not args.live):
         # ---- PURE-MATH MODE (supported) ----
         try:
             sample = [int(x) for x in args.throughput.split(",") if x.strip() != ""]
@@ -687,7 +687,7 @@ def main():
     series = [{"name": "TEAM (all)", "sample": sample, "backlog": backlog}]
     for spec in args.component:
         try:
-            name, tp, items = spec.split(":")
+            name, tp, items = spec.rsplit(":", 2)
             cs = [int(x) for x in tp.split(",") if x.strip() != ""]
             series.append({"name": name.strip(), "sample": cs, "backlog": int(items)})
         except ValueError:
@@ -707,9 +707,12 @@ def main():
 
     # ----- simulate every series --------------------------------------------
     for s in series:
-        s["mean"] = sum(s["sample"]) / len(s["sample"])
-        s["weeks"] = sim_weeks_to_finish(s["backlog"], s["sample"], args.trials, rng)
-        s["items"] = sim_items_by_date(n_weeks, s["sample"], args.trials, rng)
+        if s["sample"]:
+            s["mean"] = sum(s["sample"]) / len(s["sample"])
+            s["weeks"] = sim_weeks_to_finish(s["backlog"], s["sample"], args.trials, rng)
+            s["items"] = sim_items_by_date(n_weeks, s["sample"], args.trials, rng)
+        else:
+            s["mean"], s["weeks"], s["items"] = None, [], []
 
     # ----- cycle-time SLE (Q3) ----------------------------------------------
     cycle_sample, sle = None, {}
@@ -765,6 +768,9 @@ def main():
     L.append(f"THROUGHPUT  (items reaching Done per week, oldest → newest)")
     L.append(f"  {'series':<{NW}}   weekly counts{' '*max(0, 3*wk-13)}   mean   min  max")
     for s in series:
+        if not s["sample"]:
+            L.append(f"  {s['name']:<{NW}}   (no complete throughput weeks in window)")
+            continue
         counts = " ".join(f"{c:>2}" for c in s["sample"])
         L.append(f"  {s['name']:<{NW}}   {counts}   {s['mean']:>4.1f}   "
                  f"{min(s['sample']):>3}  {max(s['sample']):>3}")
@@ -794,6 +800,10 @@ def main():
     L.append(f"  {'series':<{NW}}   queue   50%      85%      95%      85% date")
     L.append(f"  {'-'*NW}   -----   ----     ----     ----     ----------")
     for s in series:
+        if not s["weeks"]:
+            L.append(f"  {s['name']:<{NW}}   {s['backlog']:>5}   "
+                     f"no throughput data in window — forecast unavailable")
+            continue
         w50, w85, w95 = pct(s["weeks"], 50), pct(s["weeks"], 85), pct(s["weeks"], 95)
         d85 = today + timedelta(weeks=w85)
         L.append(f"  {s['name']:<{NW}}   {s['backlog']:>5}   "
@@ -808,6 +818,9 @@ def main():
     L.append(f"  {'series':<{NW}}    95%     85%     50%")
     L.append(f"  {'-'*NW}    ---     ---     ---")
     for s in series:
+        if not s["items"]:
+            L.append(f"  {s['name']:<{NW}}   no throughput data in window — forecast unavailable")
+            continue
         L.append(f"  {s['name']:<{NW}}   {pct(s['items'],5):>4}    "
                  f"{pct(s['items'],15):>4}    {pct(s['items'],50):>4}")
     L.append("")
@@ -879,18 +892,19 @@ def main():
                 "name": s["name"],
                 "sample": s["sample"],
                 "sample_raw": s["sample_raw"],
-                "mean": round(s["mean"], 1),
-                "min": min(s["sample"]),
-                "max": max(s["sample"]),
+                "mean": round(s["mean"], 1) if s["sample"] else None,
+                "min": min(s["sample"]) if s["sample"] else None,
+                "max": max(s["sample"]) if s["sample"] else None,
                 "backlog": s["backlog"],
                 "outliers": [{"wk": i + 1, "value": v, "z": round(mz, 1)}
                              for i, v, mz in s["outliers_display"]],
                 "outlier_note": s["outlier_note"],
-                "q1": {"w50": pct(s["weeks"], 50), "w85": pct(s["weeks"], 85),
+                "q1": ({"w50": pct(s["weeks"], 50), "w85": pct(s["weeks"], 85),
                        "w95": pct(s["weeks"], 95),
-                       "date85": (today + timedelta(weeks=pct(s["weeks"], 85))).isoformat()},
-                "q2": {"c95": pct(s["items"], 5), "c85": pct(s["items"], 15),
-                       "c50": pct(s["items"], 50)},
+                       "date85": (today + timedelta(weeks=pct(s["weeks"], 85))).isoformat()}
+                      if s["weeks"] else None),
+                "q2": ({"c95": pct(s["items"], 5), "c85": pct(s["items"], 15),
+                       "c50": pct(s["items"], 50)} if s["items"] else None),
             })
         wip_out = []
         for w in wip:

--- a/.claude/scripts/gh_fetch.py
+++ b/.claude/scripts/gh_fetch.py
@@ -31,6 +31,15 @@ Item routing:
     nodes), so the truncated-changelog backfill logic can't be trusted for
     PRs without separate handling. Passing --include-prs exits with an
     error rather than silently producing wrong changelogs.
+  - Issues that are themselves a PARENT of other sub-issues (subIssuesSummary
+    .total > 0) are EXCLUDED by default too — pass --include-parents to keep
+    them. Same reasoning as Jira's Epic exclusion: a parent issue stays open/
+    in-progress for its entire sub-issue lifetime (confirmed live on #613:
+    18 sub-issues, 10 complete, parent still OPEN), so counting it as its own
+    throughput/open-queue item would badly distort both. It still works as a
+    --breakdown-field parent grouping label for its children regardless of
+    this flag — this only controls whether the parent ALSO shows up as its
+    own line item in done.json/open.json.
   - An item whose current Status is in neither --done-status nor --statuses
     is dropped but counted (`skipped_status`) and logged to stderr — this
     board has 7 status columns (not Jira's typical 3), so a misconfigured
@@ -82,6 +91,8 @@ query($org: String!, $number: Int!, $cursor: String) {
               issueType { name }
               labels(first: 20) { nodes { name } }
               repository { name }
+              parent { number title }
+              subIssuesSummary { total }
               timelineItems(itemTypes: [PROJECT_V2_ITEM_STATUS_CHANGED_EVENT], first: 50) {
                 totalCount
                 pageInfo { hasNextPage endCursor }
@@ -217,6 +228,13 @@ def components_for(content, breakdown_field):
     if breakdown_field == "issuetype":
         it = content.get("issueType")
         return [{"name": it["name"]}] if it else []
+    if breakdown_field == "parent":
+        # Group by the item's GitHub native sub-issue parent (the GH Projects
+        # analog of a Jira Epic — this board has no Epic type, so a sub-issue's
+        # linked parent is the "feature" a ticket belongs to). Standalone items
+        # (no parent) get no component and only show up in the TEAM line.
+        parent = content.get("parent")
+        return [{"name": f"#{parent['number']} {parent['title']}"}] if parent else []
     return []
 
 
@@ -282,13 +300,25 @@ def main():
                    default=["Backlog", "In progress", "In review"],
                    help="open-queue (active/backlog) status names — set to your "
                         "board's committed columns (default is a generic placeholder)")
-    p.add_argument("--breakdown-field", choices=["none", "labels", "issuetype"],
+    p.add_argument("--breakdown-field", choices=["none", "labels", "issuetype", "parent"],
                    default="none",
                    help="what to use as the forecast's --components axis "
-                        "(default none — team-only forecast)")
+                        "(default none — team-only forecast). \"parent\" breaks "
+                        "down by each item's native GitHub sub-issue parent — the "
+                        "closest analog to a Jira Epic on a board with no Epic type; "
+                        "items with no parent are counted in TEAM only.")
     p.add_argument("--include-drafts", action="store_true",
                    help="include DraftIssue project items (default: excluded — "
                         "not deliverable flow)")
+    p.add_argument("--include-parents", action="store_true",
+                   help="include issues that are themselves a parent of other "
+                        "sub-issues (default: excluded — same reasoning as Jira's "
+                        "Epic exclusion: a parent stays open/in-progress for its "
+                        "entire sub-issue lifetime, so counting it as its own "
+                        "throughput/open-queue item would badly distort both. It "
+                        "still works as a --breakdown-field parent grouping label "
+                        "for its children either way — this flag only affects "
+                        "whether the parent ALSO appears as its own line item.)")
     p.add_argument("--include-prs", action="store_true",
                    help="NOT IMPLEMENTED — PullRequest.timelineItems.totalCount does "
                         "not respect the itemTypes filter in live testing (seen "
@@ -326,6 +356,7 @@ def main():
         "total": len(all_nodes),
         "drafts_excluded": 0,
         "prs_excluded": 0,
+        "parents_excluded": 0,
         "skipped_since_filter": 0,
         "skipped_status": 0,
         "done": 0,
@@ -352,6 +383,12 @@ def main():
         elif typename != "Issue":
             stats["skipped_status"] += 1
             continue
+
+        if typename == "Issue" and not args.include_parents:
+            sub_total = (content.get("subIssuesSummary") or {}).get("total", 0)
+            if sub_total > 0:
+                stats["parents_excluded"] += 1
+                continue
 
         created_at = content.get("createdAt")
         if since_cutoff and created_at and day_from_iso(created_at) < since_cutoff:
@@ -406,6 +443,9 @@ def main():
           f"({'included' if args.include_drafts else 'default: excluded'})", file=sys.stderr)
     print(f"#   PRs excluded             : {stats['prs_excluded']} (always excluded — see docstring)",
           file=sys.stderr)
+    print(f"#   parent issues excluded   : {stats['parents_excluded']} "
+          f"({'included' if args.include_parents else 'default: excluded — sit open for their whole sub-issue lifetime'})",
+          file=sys.stderr)
     if args.since:
         print(f"#   skipped (before --since) : {stats['skipped_since_filter']}", file=sys.stderr)
     print(f"#   skipped (status not in --done-status/--statuses): {stats['skipped_status']}",
@@ -418,7 +458,8 @@ def main():
     print(f"#   resolutiondate/closedAt disagreements (>1 day, non-artifact): "
           f"{stats['resolutiondate_disagreements']}", file=sys.stderr)
     accounted = (stats["done"] + stats["open"] + stats["drafts_excluded"]
-                 + stats["prs_excluded"] + stats["skipped_since_filter"] + stats["skipped_status"])
+                 + stats["prs_excluded"] + stats["parents_excluded"]
+                 + stats["skipped_since_filter"] + stats["skipped_status"])
     print(f"#   sanity: done+open+excluded+skipped = {accounted}  (total = {stats['total']})",
           file=sys.stderr)
     print(f"#   elapsed: {time.time() - t0:.1f}s", file=sys.stderr)

--- a/.claude/scripts/run_daily_forecast.py
+++ b/.claude/scripts/run_daily_forecast.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+run_daily_forecast.py — daily driver for the vocable-android throughput-forecast
+skill. Fetches GitHub Project #50, breaks out by the Voice Selection feature
+(native sub-issue parent #613 — the --breakdown-field parent axis, this
+board's Epic-analog) forecasts, and writes a dated HTML report straight into
+the Drive-synced Metrics folder (no separate upload step: that folder IS the
+sync target on this machine).
+
+Scoped to #613 only per direct instruction, for as long as feature/voice-
+selection stays unmerged — other parents on the board (e.g. #627 Reset App
+Settings) are deliberately excluded from the breakdown, not just currently
+absent. Revisit ALLOWED_PARENT_NUMBERS once voice-selection merges to main.
+
+Meant to be invoked by a scheduled task, once a day.
+"""
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path("/Users/rhyslutsky/My Drive/Clients/Vocable/vocable-android")
+SCRIPTS = REPO_ROOT / ".claude" / "scripts"
+OUT_DIR = Path("/tmp/vocable_forecast")
+DRIVE_DIR = Path("/Users/rhyslutsky/My Drive/Clients/Vocable/Metrics")
+LATEST_NAME = "vocable-android-throughput-forecast-latest.html"
+
+# Only break out these parent issue numbers (matched by "#<N> " prefix on the
+# discovered component name, so a title edit doesn't silently drop it). Any
+# other parent found on the board is excluded from --components — deliberate
+# scope-narrowing to Voice Selection, not a stale filter to widen later.
+ALLOWED_PARENT_NUMBERS = {613}
+
+ORG = "willowtreeapps"
+PROJECT_NUMBER = 50
+REPO = "vocable-android"
+DONE_STATUSES = ["Done"]
+STATUSES = ["Pre Backlog", "Backlog", "Ready to select", "In progress",
+            "Development Complete (In Review)", "Ready for Demo"]
+WIP_STATUSES = ["In progress", "Development Complete (In Review)", "Ready for Demo"]
+RESET_STATUSES = ["Backlog", "Pre Backlog"]
+START_STATUS = "In progress"
+WEEKS = 10  # trailing complete weeks kept for the throughput sample
+
+
+def run(cmd):
+    print("+", " ".join(cmd), file=sys.stderr)
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    sys.stderr.write(r.stderr)
+    if r.returncode != 0:
+        sys.exit(f"ERROR: command failed ({r.returncode}): {' '.join(cmd)}")
+    return r.stdout
+
+
+def discover_parents(done_path, open_path):
+    names = set()
+    for p in (done_path, open_path):
+        data = json.loads(p.read_text())
+        for n in data["issues"]["nodes"]:
+            for c in n.get("fields", {}).get("components", []):
+                names.add(c["name"])
+    allowed = {n for n in names
+               if n.startswith("#") and int(n.split(" ", 1)[0][1:]) in ALLOWED_PARENT_NUMBERS}
+    dropped = names - allowed
+    if dropped:
+        print(f"# excluded parent(s) outside ALLOWED_PARENT_NUMBERS: {sorted(dropped)}",
+              file=sys.stderr)
+    return sorted(allowed)
+
+
+def main():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    DRIVE_DIR.mkdir(parents=True, exist_ok=True)
+    today = date.today().isoformat()
+
+    run(["python3", str(SCRIPTS / "gh_fetch.py"),
+         "--org", ORG, "--project-number", str(PROJECT_NUMBER), "--repo", REPO,
+         "--done-status", *DONE_STATUSES,
+         "--statuses", *STATUSES,
+         "--breakdown-field", "parent",
+         "--out-dir", str(OUT_DIR)])
+
+    done_path, open_path = OUT_DIR / "done.json", OUT_DIR / "open.json"
+    parents = discover_parents(done_path, open_path)
+    print(f"# discovered {len(parents)} parent(s): {parents}", file=sys.stderr)
+
+    json_out = OUT_DIR / "forecast.json"
+    forecast_cmd = ["python3", str(SCRIPTS / "forecast.py"),
+                    "--done", str(done_path), "--open", str(open_path),
+                    "--changelog", str(done_path), str(open_path),
+                    "--project", "Vocable-Android",
+                    "--wip-status", *WIP_STATUSES,
+                    "--reset-status", *RESET_STATUSES, "--start-status", START_STATUS,
+                    "--weeks", str(WEEKS), "--today", today,
+                    "--json-out", str(json_out)]
+    if parents:
+        forecast_cmd += ["--components", *parents]
+    run(forecast_cmd)
+
+    dated_path = DRIVE_DIR / f"vocable-android-throughput-forecast-{today}.html"
+    run(["python3", str(SCRIPTS / "forecast-html.py"), str(json_out), str(dated_path)])
+
+    latest_path = DRIVE_DIR / LATEST_NAME
+    latest_path.write_bytes(dated_path.read_bytes())
+    print(f"# wrote {dated_path}")
+    print(f"# wrote {latest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/throughput-forecast/SKILL.md
+++ b/.claude/skills/throughput-forecast/SKILL.md
@@ -114,23 +114,48 @@ is wrong — fix it, don't hand-assemble numbers.
 | `--repo` | repo name (for the timeline-backfill query and issue keys) |
 | `--done-status …` | status name(s) counted as delivered |
 | `--statuses …` | open-queue (active/backlog) status names |
-| `--breakdown-field none\|labels\|issuetype` | what feeds forecast.py's `--components` axis |
+| `--breakdown-field none\|labels\|issuetype\|parent` | what feeds forecast.py's `--components` axis |
 | `--include-drafts` | include DraftIssue project items (default: excluded) |
 | `--include-prs` | **not implemented** — see the script's docstring; a real PR showed `timelineItems.totalCount` not respecting the itemTypes filter, so the truncated-changelog backfill can't be trusted for PRs yet |
+| `--include-parents` | include issues that are themselves a parent of other sub-issues as their own line item (default: excluded — see below) |
 | `--since YYYY-MM-DD` | only include items created on/after this date |
 
 `forecast.py`'s own flags are unchanged from the Jira version — see its
 `--help` or the original skill's docs for the full table (`--weeks`,
 `--by-date`, `--outliers`, `--cycle-max-days`, `--json-out`, etc.).
 
-## DraftIssue and PullRequest are excluded (default) — the Epic-exclusion analog
+## DraftIssue, PullRequest, and parent issues are excluded (default) — the Epic-exclusion analog
 
 The Jira version excludes `issuetype = Epic` by default (placeholders, not
-deliverable flow). GitHub Projects v2 has no Epic concept, but has two
+deliverable flow). GitHub Projects v2 has no Epic concept, but has three
 analogous "not deliverable flow" categories: **DraftIssue** items (notes, not
-real issues — excluded by default, `--include-drafts` to opt in) and
-**PullRequest** items (already reachable via an issue's linked PRs — always
-excluded; `--include-prs` is not yet implemented, see above).
+real issues — excluded by default, `--include-drafts` to opt in), **PullRequest**
+items (already reachable via an issue's linked PRs — always excluded;
+`--include-prs` is not yet implemented, see above), and **parent issues** —
+an issue that is itself the parent of other sub-issues (confirmed live on
+#613: 18 sub-issues, 10 complete, parent still `OPEN`). A parent stays
+open/in-progress for its *entire* sub-issue lifetime, so counting it as its
+own throughput/open-queue item would badly distort both — same reasoning as
+the Epic exclusion, just GitHub's structural equivalent. Excluded by default;
+`--include-parents` to opt in. A parent still works as a `--breakdown-field
+parent` grouping label for its children regardless of this flag — the flag
+only controls whether the parent *also* shows up as its own line item.
+
+## Breaking down by parent (the Epic-analog grouping)
+
+`--breakdown-field parent` groups Q1/Q2 by each item's native GitHub
+sub-issue parent (e.g. `"#613 Feature: Voice Selection — Hybrid…"`) instead
+of by label or issue type — the closest thing this board has to a Jira
+Epic/feature grouping, since it has no Epic issue type. Items with no parent
+link don't get a component and only show up in the TEAM line. If a project
+has multiple unrelated parents on the board, you'll likely want to filter
+`forecast.py --components` down to just the ones relevant to the current
+ask (see `run_daily_forecast.py`'s `ALLOWED_PARENT_NUMBERS` pattern for an
+example that scopes a scheduled report to one feature) rather than passing
+every discovered parent through — a component series with very few or zero
+Done items in the window renders as "no throughput data in window" rather
+than crashing (both `forecast.py` and `forecast-html.py` handle a
+zero-length sample series gracefully for exactly this reason).
 
 ## Cycle-time basis — started→Done (Q3/Q4)
 

--- a/.claude/skills/throughput-forecast/config.yaml
+++ b/.claude/skills/throughput-forecast/config.yaml
@@ -10,10 +10,16 @@ github:
 
 # Optional breakdown axis for Q1/Q2 (forecast.py's --components). This board
 # has no "Components" field and sparse labels, so the default is a team-only
-# forecast. Set to "issuetype" to break out by Task/Bug/Feature instead, or
-# "labels" if labels start getting used consistently.
-breakdown_field: none              # none | labels | issuetype
+# forecast. Set to "issuetype" to break out by Task/Bug/Feature instead,
+# "labels" if labels start getting used consistently, or "parent" to break
+# out by each item's native GitHub sub-issue parent — the closest analog to
+# a Jira Epic/feature grouping on a board with no Epic type (see
+# create-ticket's "Linking sub-issues to their parent" for how those links
+# get set). Items with no parent link only show up in the TEAM line.
+breakdown_field: none              # none | labels | issuetype | parent
 components: []                     # e.g. ["Task", "Bug", "Feature"] if breakdown_field: issuetype
+                                    # (leave empty for "parent" — the parent set is
+                                    # discovered per run, not fixed in advance)
 
 throughput:
   # Status name(s) that mean "delivered". (--done-status)

--- a/Documentation/work-log/664-parent-breakdown-daily-forecast.md
+++ b/Documentation/work-log/664-parent-breakdown-daily-forecast.md
@@ -1,0 +1,98 @@
+# #664 — throughput-forecast: breakdown by parent, exclude parent-container issues, daily Voice Selection report
+
+## What
+
+Extended the GitHub-Projects throughput-forecast skill (built in #653) so it
+can forecast a single feature's delivery, not just team-wide throughput:
+
+- `gh_fetch.py`: new `--breakdown-field parent` groups items by their native
+  GitHub sub-issue parent (e.g. `"#613 Feature: Voice Selection — Hybrid…"`),
+  and (this issue's own addition) issues that are themselves a parent of
+  other sub-issues are now **excluded from done/open by default**
+  (`--include-parents` to opt in) — the same reasoning as the Jira Epic
+  exclusion, applied to GitHub's structural equivalent.
+- `forecast.py`/`forecast-html.py`: handle a `--components` series with zero
+  throughput weeks gracefully (renders "no throughput data in window"
+  instead of a `ZeroDivisionError`/crash) — needed because a freshly-linked
+  parent group can easily have no Done items yet.
+- `run_daily_forecast.py` (new): a scheduled-task driver that fetches
+  Project #50, forecasts scoped to Voice Selection (`#613`) only via an
+  allowlist, and writes a dated + "latest" HTML report straight into the
+  Drive-synced `Metrics` folder.
+- `SKILL.md`/`config.yaml` updated to document all of the above.
+
+## Why
+
+The team wants delivery visibility scoped to Voice Selection specifically,
+not just team-wide throughput. This board has no Epic issue type, so there's
+no built-in "feature" grouping — but the native GitHub sub-issue parent link
+(added in #654) gives us exactly that, once two gaps are closed: the parent
+issue itself needs to be excluded (it sits open for its whole sub-issue
+lifetime and would badly distort its own group — confirmed live: #613 has 18
+sub-issues, 10 complete, and is still `OPEN`), and the forecast engine needs
+to tolerate a component series that has too little (or zero) history without
+crashing.
+
+## Key decisions
+
+**This breaks byte-for-byte parity between `forecast.py` and the upstream
+Jira skill, established as a deliberate goal in #653 — worth being explicit
+about, since a reviewer on #655 specifically praised keeping it unmodified.**
+The zero-length-series guards (`if s["sample"]:` branches in the Q1/Q2/JSON
+sections, `rsplit(":", 2)` instead of `split(":")` for component names that
+may contain colons) are genuine behavioral fixes needed to support
+`--breakdown-field parent` safely, not cosmetic changes — a parent-scoped
+series realistically can have zero Done items in a 10-26 week window, and
+component/parent titles routinely contain colons (`"Day 2: Capture…"` style),
+which the original `spec.split(":")` would mis-parse. Both are real bugs
+`--breakdown-field parent` exposes that `labels`/`issuetype` mostly wouldn't.
+This trades the "clean upstream diff" property (defended in #653/#655) for
+correctness under the new breakdown axis — a straight upstream sync is no
+longer possible without re-reconciling these fixes, and that's the right
+call here, but should stay visible rather than get silently reintroduced as
+an implicit assumption next time someone touches these files.
+
+**Parent-container exclusion uses `subIssuesSummary.total > 0`, not issue
+type or title conventions.** This is a structural check (does this issue
+have sub-issues linked to it), not a naming/labeling heuristic — confirmed
+against #613 live before writing the fix, and it composes correctly with
+`--breakdown-field parent`: an item can simultaneously be *excluded* from
+done/open (because it has children) and still *used* as the grouping label
+for those same children, since the exclusion check and the grouping lookup
+(`content.parent`) look at different relationships (this item's own
+children vs. this item's own parent).
+
+**`run_daily_forecast.py` hardcodes its own repo/Drive paths and a narrow
+`ALLOWED_PARENT_NUMBERS = {613}` allowlist** rather than reading
+`config.yaml` — this is a single-purpose scheduled-task script for this one
+feature's reporting cadence, not a generic reusable skill entry point (that
+role stays with `gh_fetch.py`/`forecast.py` driven through `SKILL.md`). The
+allowlist is deliberate scope-narrowing (per direct instruction), not a
+placeholder to widen later — revisit once voice-selection merges to `main`,
+per its own docstring.
+
+## Verification
+
+- Confirmed live: #613 has `subIssuesSummary.total = 18`, `completed = 10`,
+  `state = OPEN` — the exact "sits open for its whole lifetime" case this
+  exclusion targets.
+- Ran `gh_fetch.py --breakdown-field parent` against the real Project #50:
+  322 total items, 168 done / 55 open / 50 drafts / 43 PRs / **4 parent
+  issues excluded** / 2 skipped — sums to 322. Confirmed #613 is absent from
+  both `done.json` and `open.json`, while its sub-issues correctly carry the
+  `"#613 Feature: Voice Selection…"` grouping label.
+  Discovered 3 parent groups on the board in total (`#613`, `#615` "Day 1
+  SPIKE…", `#627` "Reset App Settings"); `run_daily_forecast.py`'s allowlist
+  correctly narrows this to just `#613`.
+- Ran the full `run_daily_forecast.py` end-to-end: `gh_fetch.py` →
+  `forecast.py` → `forecast-html.py`, writing both a dated and "latest" HTML
+  report into the Drive-synced Metrics folder. Terminal summary showed the
+  `#613` series's own throughput distinct from TEAM (`tp [0,0,0,0,0,0,0,0,0,2]
+  open 5` vs. team's `[1,2,3,15,3,1,1,1,1,4] open 55`) — confirming the
+  breakdown is real, not just a relabeled copy of the team line.
+
+## Links
+
+- Issue: #664
+- Prior work: #653 (GitHub Projects port), #654 (create-ticket project auto-add/sub-issue linking)
+- Project: https://github.com/orgs/willowtreeapps/projects/50/views/1


### PR DESCRIPTION
## Summary
- Adds `--breakdown-field parent` to `gh_fetch.py` — groups items by their native GitHub sub-issue parent (e.g. `"#613 Feature: Voice Selection — Hybrid…"`), the closest thing this board has to a Jira Epic/feature grouping.
- Excludes issues that are themselves a parent of other sub-issues from `done`/`open` by default (`--include-parents` to opt in) — confirmed live that #613 has 18 sub-issues (10 complete) and is still `OPEN`, so counting it as its own item would badly distort its own group.
- `forecast.py`/`forecast-html.py` now handle a zero-throughput component series without crashing, and component-name parsing tolerates colons in titles (parent/issue titles routinely have them).
- Adds `run_daily_forecast.py`, a scheduled-task driver scoped to Voice Selection (`#613`) that writes a dated + "latest" HTML report to the Drive-synced Metrics folder.
- `SKILL.md`/`config.yaml` document all of the above.

**Note on scope**: this breaks byte-for-byte parity between `forecast.py` and the upstream Jira skill, which #653/#655 deliberately established and a reviewer specifically praised keeping intact. That tradeoff is deliberate and documented in the work-log — the zero-series guards and colon-tolerant parsing are real behavioral fixes the `parent` breakdown axis needs, not cosmetic changes, so re-syncing with upstream `forecast.py` in the future will need manual reconciliation rather than a straight diff.

## Ticket
Closes #664 — linked via `createLinkedBranch` at ticket-creation time, so it shows under Development regardless of this PR's target branch.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Tests
- [ ] CI/CD
- [ ] Documentation

## Testing
- [ ] Unit tests added/updated — N/A, one-shot data/report-generation scripts, not app code
- [ ] Integration tests added/updated — N/A, same reason
- [x] Manual testing performed — full end-to-end run against real Project #50 data via `run_daily_forecast.py`; see `Documentation/work-log/664-parent-breakdown-daily-forecast.md` for verification detail (item-count reconciliation, confirmed #613 excluded while its sub-issues carry the grouping label, confirmed the #613 series's throughput is distinct from TEAM's)

## Checklist
- [ ] Tests pass locally (`./gradlew testDebug`) — N/A, no app code (`app/`) touched
- [x] No API keys or secrets in code — same `gh api graphql`/`gh auth` pattern as #653
- [ ] CLAUDE.md updated (if new pattern introduced) — not updated; doesn't introduce an app-development pattern

See `Documentation/work-log/664-parent-breakdown-daily-forecast.md` for the complete writeup.
