### PR TITLE
Reset: full preference wipe + defaults inventory

### DIFF
--- a/Documentation/work-log/638-reset-preference-wipe.md
+++ b/Documentation/work-log/638-reset-preference-wipe.md
@@ -1,0 +1,38 @@
+# Reset: full preference wipe + defaults inventory
+
+**Issue:** #638 (Part of #627 — Reset App Settings epic)
+
+## What was needed
+
+#627 requires Android's reset to mirror iOS's `AppResetController.performReset()`: an unconditional wipe of every stored preference, not a curated subset, with each one falling back to a defined default on next read. Before any reset trigger can be built (#640) or the category/phrase wipe added (#639), this ticket needed a confirmed inventory of every `IVocableSharedPreferences`-backed setting and proof each has a real default — plus a wipe mechanism that's actually reachable through the interface, not just the concrete class.
+
+## What changed
+
+- **Inventoried every preference** on `IVocableSharedPreferences`/`VocableSharedPreferences`: `mySayings` (empty list), `dwellTime` (1000L), `sensitivity` (0.1F), `headTrackingEnabled` (true), `selectedVoiceName` (null/unset), `firstTime` (true). All six already had correct defaults — no default-value bugs found. One unused legacy constant, `KEY_MY_LOCALIZED_SAYINGS`, exists but isn't exposed by any getter/setter; left untouched since it's dead weight, not a live preference, and `clearAll()`'s `SharedPreferences.clear()` wipes the whole encrypted store regardless of which keys are named as constants.
+- **Promoted `clearAll()` to `IVocableSharedPreferences`.** The wipe itself (`encryptedPrefs.edit(commit = true) { clear() }`) already existed and was already a full, unconditional store clear — it just lived only on the concrete `VocableSharedPreferences` class, reachable only by callers holding that concrete type instead of the interface everything else in this codebase is injected against. It's now an interface method so a future reset use case (#640) can call it through normal DI.
+- **Named the two remaining inline defaults**: `DEFAULT_HEAD_TRACKING_ENABLED` and `DEFAULT_FIRST_TIME` (both `true`), alongside the existing `DEFAULT_SENSITIVITY`/`DEFAULT_DWELL_TIME` constants, so every default has one canonical source instead of a literal buried in a `getX(key, true)` call.
+- **Added `FakeVocableSharedPreferences.clearAll()`**, resetting all six backing fields to the same production defaults (via the named constants above, not re-typed literals).
+- **Fixed a pre-existing bug in the fake**: `setFirstTime()` set `firstTime = true`, the inverse of production's `setFirstTime()` (which writes `false`, marking first-launch as consumed). Caught because writing the reset test required reasoning about this preference's real semantics. No existing test relied on the old behavior — `SplashViewModel`, the only caller of `setFirstTime()`/`getFirstTime()`, has no unit test yet (already noted as a coverage gap in `CLAUDE.md`).
+- **Added `VocableSharedPreferencesResetTest`** (`app/src/test/java/com/willowtree/vocable/core/`), one test per preference: seed a non-default value via the fake's constructor, call `clearAll()`, assert the getter returns the documented default.
+
+## Key decision: testing strategy
+
+`VocableSharedPreferences` is backed by `EncryptedSharedPreferences`, which needs a real `Context`/Android Keystore — there's no Robolectric in this repo (per `CLAUDE.md`), so it can't be exercised from a JVM unit test. The reset test instead pins the contract via `FakeVocableSharedPreferences`, which mirrors `IVocableSharedPreferences` and now shares the same default constants as production. This documents and regression-guards the expected default for each preference; it does not exercise the real encrypted store's `clear()` call, which remains implicitly covered by `VocableKoinTestRule` resetting real prefs between instrumented tests.
+
+## Resolved: voice preference reset behavior
+
+#627's original open PM decision — whether Android's voice-selection reset should mirror iOS's incidental `nil` fallback or deliberately restore a chosen default — was resolved before this ticket started: per Chris Stroud (Slack, 2026-08-04), an unset `selectedVoiceName` (falling back to the system voice) is the correct, intended end state, matching iOS and a fresh install. `getSelectedVoiceName()`'s existing `null` default already satisfies this; no code change was needed for it specifically. `Documentation/reset-app-settings-ios-reference.md` still describes this as an open/unresolved question and is stale — the resolution lives in #627's issue body, not that doc.
+
+## Branch note
+
+This branch (`feature/638/reset-preference-wipe`) is based on `feature/voice-selection`, not `main`, because `selectedVoiceName`/`firstTime` (and the interface methods for them) don't exist on `main` yet — voice selection (#613) hasn't merged. The PR targets `feature/voice-selection` accordingly; per this repo's convention for sub-issue PRs targeting a parent's integration branch, `closes #638` won't auto-fire on merge, so the issue needs to be closed manually afterward with a link to the merged PR.
+
+## Out of scope (tracked in sibling issues under #627)
+
+- Category/phrase data reset (#639)
+- Reset UI entry point/confirmation dialog and actually wiring `clearAll()` up to a user-facing action (#640)
+
+## Pointers
+
+- Issue: #638 · Parent: #627 · Reference: `Documentation/reset-app-settings-ios-reference.md`
+- Files: `core/IVocableSharedPreferences.kt`, `core/VocableSharedPreferences.kt`, `utils/FakeVocableSharedPreferences.kt`, `core/VocableSharedPreferencesResetTest.kt` (new)

--- a/app/src/main/java/com/willowtree/vocable/core/IVocableSharedPreferences.kt
+++ b/app/src/main/java/com/willowtree/vocable/core/IVocableSharedPreferences.kt
@@ -32,4 +32,6 @@ interface IVocableSharedPreferences {
     fun setFirstTime()
 
     fun getFirstTime(): Boolean
+
+    fun clearAll()
 }

--- a/app/src/main/java/com/willowtree/vocable/core/VocableSharedPreferences.kt
+++ b/app/src/main/java/com/willowtree/vocable/core/VocableSharedPreferences.kt
@@ -27,6 +27,8 @@ class VocableSharedPreferences :
         const val DEFAULT_DWELL_TIME = DWELL_TIME_ONE_SECOND
         const val KEY_SELECTED_VOICE_NAME = "KEY_SELECTED_VOICE_NAME"
         const val KEY_FIRST_TIME = "KEY_FIRST_TIME_OPENING"
+        const val DEFAULT_HEAD_TRACKING_ENABLED = true
+        const val DEFAULT_FIRST_TIME = true
     }
 
     private val encryptedPrefs: SharedPreferences by lazy {
@@ -80,7 +82,7 @@ class VocableSharedPreferences :
     }
 
     override fun getHeadTrackingEnabled(): Boolean =
-        encryptedPrefs.getBoolean(KEY_HEAD_TRACKING_ENABLED, true)
+        encryptedPrefs.getBoolean(KEY_HEAD_TRACKING_ENABLED, DEFAULT_HEAD_TRACKING_ENABLED)
 
     override fun setSelectedVoiceName(voiceName: String?) {
         encryptedPrefs.edit {
@@ -99,10 +101,10 @@ class VocableSharedPreferences :
     }
 
     override fun getFirstTime(): Boolean =
-        encryptedPrefs.getBoolean(KEY_FIRST_TIME, true)
+        encryptedPrefs.getBoolean(KEY_FIRST_TIME, DEFAULT_FIRST_TIME)
 
     @SuppressLint("ApplySharedPref")
-    fun clearAll() {
+    override fun clearAll() {
         encryptedPrefs.edit(commit = true) { clear() }
     }
 }

--- a/app/src/test/java/com/willowtree/vocable/core/VocableSharedPreferencesResetTest.kt
+++ b/app/src/test/java/com/willowtree/vocable/core/VocableSharedPreferencesResetTest.kt
@@ -1,0 +1,68 @@
+package com.willowtree.vocable.core
+
+import com.willowtree.vocable.utils.FakeVocableSharedPreferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * There's no Robolectric in this repo, so the real EncryptedSharedPreferences-backed
+ * [VocableSharedPreferences] can't be exercised from a JVM unit test. This instead pins the
+ * documented defaults via [FakeVocableSharedPreferences], which mirrors the production contract.
+ */
+class VocableSharedPreferencesResetTest {
+
+    @Test
+    fun `clearAll resets My Sayings to empty`() {
+        val prefs = FakeVocableSharedPreferences(mySayings = listOf("Hello", "Thanks"))
+
+        prefs.clearAll()
+
+        assertEquals(emptyList<String>(), prefs.getMySayings())
+    }
+
+    @Test
+    fun `clearAll resets dwell time to one second`() {
+        val prefs = FakeVocableSharedPreferences(dwellTime = 3000L)
+
+        prefs.clearAll()
+
+        assertEquals(VocableSharedPreferences.DEFAULT_DWELL_TIME, prefs.getDwellTime())
+    }
+
+    @Test
+    fun `clearAll resets sensitivity to medium`() {
+        val prefs = FakeVocableSharedPreferences(sensitivity = 0.9f)
+
+        prefs.clearAll()
+
+        assertEquals(VocableSharedPreferences.DEFAULT_SENSITIVITY, prefs.getSensitivity())
+    }
+
+    @Test
+    fun `clearAll resets head tracking enabled to true`() {
+        val prefs = FakeVocableSharedPreferences(headTrackingEnabled = false)
+
+        prefs.clearAll()
+
+        assertEquals(VocableSharedPreferences.DEFAULT_HEAD_TRACKING_ENABLED, prefs.getHeadTrackingEnabled())
+    }
+
+    @Test
+    fun `clearAll resets selected voice to unset`() {
+        val prefs = FakeVocableSharedPreferences(selectedVoiceName = "Aria")
+
+        prefs.clearAll()
+
+        assertNull(prefs.getSelectedVoiceName())
+    }
+
+    @Test
+    fun `clearAll resets first time to true`() {
+        val prefs = FakeVocableSharedPreferences(firstTime = false)
+
+        prefs.clearAll()
+
+        assertEquals(VocableSharedPreferences.DEFAULT_FIRST_TIME, prefs.getFirstTime())
+    }
+}

--- a/app/src/test/java/com/willowtree/vocable/utils/FakeVocableSharedPreferences.kt
+++ b/app/src/test/java/com/willowtree/vocable/utils/FakeVocableSharedPreferences.kt
@@ -2,6 +2,10 @@ package com.willowtree.vocable.utils
 
 import android.content.SharedPreferences
 import com.willowtree.vocable.core.IVocableSharedPreferences
+import com.willowtree.vocable.core.VocableSharedPreferences.Companion.DEFAULT_DWELL_TIME
+import com.willowtree.vocable.core.VocableSharedPreferences.Companion.DEFAULT_FIRST_TIME
+import com.willowtree.vocable.core.VocableSharedPreferences.Companion.DEFAULT_HEAD_TRACKING_ENABLED
+import com.willowtree.vocable.core.VocableSharedPreferences.Companion.DEFAULT_SENSITIVITY
 
 
 class FakeVocableSharedPreferences(
@@ -62,10 +66,19 @@ class FakeVocableSharedPreferences(
     }
 
     override fun setFirstTime() {
-        firstTime = true
+        firstTime = false
     }
 
     override fun getFirstTime(): Boolean {
         return firstTime
+    }
+
+    override fun clearAll() {
+        mySayings = listOf()
+        dwellTime = DEFAULT_DWELL_TIME
+        sensitivity = DEFAULT_SENSITIVITY
+        headTrackingEnabled = DEFAULT_HEAD_TRACKING_ENABLED
+        selectedVoiceName = null
+        firstTime = DEFAULT_FIRST_TIME
     }
 }


### PR DESCRIPTION
## Summary
- Inventoried every `IVocableSharedPreferences`-backed setting (`mySayings`, `dwellTime`, `sensitivity`, `headTrackingEnabled`, `selectedVoiceName`, `firstTime`) and confirmed each already has a correct, defined default
- Promoted the existing `clearAll()` full-wipe method onto `IVocableSharedPreferences` so it's reachable through DI like every other preference method, instead of only on the concrete class
- Named the two remaining inline defaults (`DEFAULT_HEAD_TRACKING_ENABLED`, `DEFAULT_FIRST_TIME`) alongside the existing `DEFAULT_SENSITIVITY`/`DEFAULT_DWELL_TIME` constants
- Fixed an inverted `setFirstTime()` in `FakeVocableSharedPreferences` (was setting `true` instead of `false`), caught while writing the reset test
- Added `VocableSharedPreferencesResetTest` — one test per preference, verifying `clearAll()` restores its documented default

## Ticket
Part of #627 — closes #638

Note: since this PR targets `feature/voice-selection` (the Voice Selection integration branch — see below) rather than `main`, GitHub's `closes` won't auto-fire on merge. Will close #638 manually with a link to this PR once merged.

**Why this branch is based on `feature/voice-selection`, not `main`:** `selectedVoiceName` and `firstTime` (and their `IVocableSharedPreferences` methods) only exist on `feature/voice-selection` — voice selection (#613) hasn't merged to `main` yet. #638's acceptance criteria explicitly requires covering voice reset, so this needed to build on top of that branch.

**Resolved voice-fallback decision:** #627's original open PM question (mirror iOS's incidental nil-fallback vs. deliberately restore a default voice) was resolved before this ticket started — per Chris Stroud (Slack, 2026-08-04), an unset `selectedVoiceName` (falling back to system voice) is the correct intended end state. `getSelectedVoiceName()`'s existing `null` default already satisfies this. `Documentation/reset-app-settings-ios-reference.md` still frames this as unresolved and is stale relative to #627's issue body.

Full details in `Documentation/work-log/638-reset-preference-wipe.md`.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [x] Tests
- [ ] CI/CD
- [x] Documentation

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist
- [x] Tests pass locally (`./gradlew testDebug`)
- [x] No API keys or secrets in code
- [ ] CLAUDE.md updated (if new pattern introduced)