### PR TITLE
Reset: category/phrase data wipe + reseed

### DIFF
--- a/Documentation/work-log/639-reset-category-phrase-reseed.md
+++ b/Documentation/work-log/639-reset-category-phrase-reseed.md
@@ -1,0 +1,38 @@
+# Reset: category/phrase data wipe + reseed
+
+**Issue:** #639 (Part of #627 — Reset App Settings epic)
+
+## What was needed
+
+#360 made preset categories user-editable/deletable via a "shadow phrase/category" mechanism (edit a preset → soft-delete the preset row, insert a stored row reusing the same id) but never built the reset path its own acceptance criteria assumed would exist. #627 requires Android to mirror iOS: delete every `Phrase`/`Category` row and re-seed from the bundled presets, exactly reversing any #360-driven edit, hide, deletion, or addition — not just the preset shadows, genuine user-added categories/phrases too.
+
+## What changed
+
+- **New DAO-level bulk deletes**: `deleteAllCategories()` (`CategoryDao`), `deleteAllPhrases()` (`PhraseDao`), `deleteAllPresetCategories()` (`PresetCategoryDao`), `deleteAllPresetPhrases()` (`PresetPhrasesDao`) — none of the four DAOs had any "delete everything" query before this; the closest existing thing was the stock `RoomDatabase.clearAllTables()`, which was deliberately not used here since it clears all four tables in one shot with no chance to reseed in between and isn't exercised per-repository the way the rest of this layer's tests are structured.
+- **`RoomPresetCategoriesRepository` gained a public `populateDatabase()`**, wrapping the existing private `ensurePopulated()` — mirroring `RoomPresetPhrasesRepository`'s existing `populateDatabase()`. Previously `ensurePopulated()` for categories only ran implicitly (`.onStart{}` on the `getPresetCategories()` flow, or before each mutating call), so there was no way to force a deterministic reseed from outside the repository.
+- **`ICategoriesUseCase.resetToDefaults()` / `IPhrasesUseCase.resetToDefaults()`** added. `PhrasesUseCase.resetToDefaults()` deletes all stored + preset phrase rows, then repopulates presets. `CategoriesUseCase.resetToDefaults()` delegates to `phrasesUseCase.resetToDefaults()` first (it already holds a `PhrasesUseCase` reference for `deleteCategory`'s existing phrase cascade, so this reuses that same orchestration seam), then deletes all stored + preset category rows and repopulates. **A single call — `categoriesUseCase.resetToDefaults()` — is the one entry point #640 needs to wire to the reset button**, matching how `deleteCategory` already cascades into phrases through the same collaborator.
+- **Fakes updated**: `FakeCategoriesUseCase.resetToDefaults()` / `FakePhrasesUseCase.resetToDefaults()` added as unimplemented stubs (`TODO`/`error`, matching each fake's existing convention for methods no current ViewModel test exercises) — required just to keep both fakes compiling against the expanded interfaces.
+- **Tests**: 3 new cases in `CategoriesUseCaseTest` (reset after category edit / deletion / custom addition) and 4 new cases in `PhrasesUseCaseTest` (reset after phrase edit / deletion / custom addition, plus Recents clearing) — all androidTest, real in-memory Room, following the existing file's established pattern rather than introducing a new one.
+
+## Why "Recents resets to empty" needed its own explicit test
+
+Recents has no dedicated table — it's derived live from `last_spoken_date` on both `Phrase` and `PresetPhrase` (`PhraseDao.getRecentPhrases`/`PresetPhrasesDao.getRecentPhrases`, both `WHERE last_spoken_date IS NOT NULL`). A full wipe-and-reseed satisfies "Recents empty" for free as long as the reseed inserts fresh rows with `lastSpokenDate = null` — which it does, since `RoomPresetPhrasesRepository`'s populate path already builds every `PresetPhraseDto` with `lastSpokenDate = null`. `reset_clears_recents` pins this explicitly rather than trusting it as an implied side effect, since a future change to the reseed path that forgot to null out spoken dates would silently break Recents without any other test catching it.
+
+## Known gap: no Compose UI test yet
+
+#639's acceptance criteria calls for "an instrumented UI test confirming post-reset state matches a fresh install's default category/phrase set exactly." What's here is instrumented (`androidTest`, real Room, real `Context`-backed resources) but exercises the use-case layer directly — there is no reset button or confirmation dialog to drive from Compose yet, since that's #640's scope (Settings UI entry point). A true UI-level test belongs on #640, once there's a screen action to click; this ticket verifies the underlying data operation is correct so #640 isn't debugging both the wiring and the reset logic at once.
+
+## Not touched
+
+- **`ensurePopulated()`'s pre-existing additive-only limitation** (documented in `arrays.xml` and CLAUDE.md — it never revives a `deleted=1` row or fixes drifted `sort_order`/`hidden` on a row that already exists) is irrelevant to this ticket's reset path specifically, because reset always starts from a fully empty table (every row hard-deleted first) — every entry is "new" on the reseed pass, so the additive/non-reconciling behavior that causes the PR #611 bug class never comes into play here. It's still a live gap for the *normal*, non-reset cold-start path; out of scope to fix in this ticket.
+- **`CategoriesUseCase.moveCategoryUp`/`moveCategoryDown`'s unguarded read-then-write race** (flagged in CLAUDE.md) — untouched, unrelated to reset.
+- **Preference wipe** (#638, merged into this branch) and **the reset UI entry point/confirmation dialog** (#640) — both explicitly out of scope per the ticket.
+
+## Branch note
+
+Same stack as #638: this branch (`feature/639/reset-category-phrase-reseed`) is based on `feature/638/reset-preference-wipe`, which is itself based on `feature/voice-selection`. PR targets `feature/638/reset-preference-wipe` to avoid rebasing/merge churn while both are in flight; per this repo's sub-issue convention, `closes #639` won't auto-fire on merge into a non-default branch, so the issue needs to be closed manually afterward with a link to the merged PR.
+
+## Pointers
+
+- Issue: #639 · Parent: #627 · Related: #360 (why reset isn't a pure settings-values reset) · Sibling: #638 (preference wipe, same branch stack)
+- Files: `data/room/{CategoryDao,PhraseDao,PresetCategoryDao,PresetPhrasesDao}.kt`, `data/repository/{StoredCategoriesRepository,RoomStoredCategoriesRepository,StoredPhrasesRepository,RoomStoredPhrasesRepository,PresetCategoriesRepository,RoomPresetCategoriesRepository,PresetPhrasesRepository,RoomPresetPhrasesRepository}.kt`, `domain/usecase/{ICategoriesUseCase,CategoriesUseCase,IPhrasesUseCase,PhrasesUseCase}.kt`, `FakeCategoriesUseCase.kt`, `FakePhrasesUseCase.kt`, `androidTest/.../{CategoriesUseCaseTest,PhrasesUseCaseTest}.kt`

--- a/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/CategoriesUseCaseTest.kt
@@ -143,4 +143,48 @@ class CategoriesUseCaseTest {
 
         assertEquals(7, useCase.categories().first().size)
     }
+
+    @Test
+    fun reset_after_category_edit_restores_preset_category() = runTest {
+        val useCase = createUseCase()
+        useCase.updateCategoryName(
+            categoryId = PresetCategories.GENERAL.id,
+            localizedName = LocalesWithText(mapOf("en_US" to "Renamed"))
+        )
+        val edited = useCase.categories().first().first { it.categoryId == PresetCategories.GENERAL.id }
+        assertEquals(true, edited is Category.StoredCategory)
+
+        useCase.resetToDefaults()
+
+        val categories = useCase.categories().first()
+        assertEquals(7, categories.size)
+        val reset = categories.first { it.categoryId == PresetCategories.GENERAL.id }
+        assertEquals(true, reset is Category.PresetCategory)
+    }
+
+    @Test
+    fun reset_after_category_deletion_restores_preset_category() = runTest {
+        val useCase = createUseCase()
+        useCase.deleteCategory(PresetCategories.GENERAL.id)
+        assertEquals(6, useCase.categories().first().size)
+
+        useCase.resetToDefaults()
+
+        val categories = useCase.categories().first()
+        assertEquals(7, categories.size)
+        assertEquals(true, categories.any { it.categoryId == PresetCategories.GENERAL.id })
+    }
+
+    @Test
+    fun reset_after_custom_category_addition_removes_it() = runTest {
+        val useCase = createUseCase()
+        useCase.addCategory("My Custom Category")
+        assertEquals(8, useCase.categories().first().size)
+
+        useCase.resetToDefaults()
+
+        val categories = useCase.categories().first()
+        assertEquals(7, categories.size)
+        assertEquals(true, categories.none { it is Category.StoredCategory })
+    }
 }

--- a/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
+++ b/app/src/androidTest/java/com/willowtree/vocable/PhrasesUseCaseTest.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.willowtree.vocable.basetest.utils.FakeLocaleProvider
 import com.willowtree.vocable.domain.model.CustomPhrase
 import com.willowtree.vocable.domain.model.PresetCategories
+import com.willowtree.vocable.domain.model.PresetPhrase
 import com.willowtree.vocable.data.room.PhraseDto
 import com.willowtree.vocable.data.repository.RoomPresetPhrasesRepository
 import com.willowtree.vocable.data.repository.RoomStoredPhrasesRepository
@@ -135,6 +136,78 @@ class PhrasesUseCaseTest {
             ),
             useCase.getPhrasesForCategory(PresetCategories.GENERAL.id)
         )
+    }
+
+    @Test
+    fun reset_after_phrase_edit_restores_preset_phrase() = runTest {
+        presetPhrasesRepository.populateDatabase()
+        val useCase = createUseCase()
+        val entryNames = getResourceNamesForCategory("category_general")
+        val phraseId = entryNames.first()
+
+        useCase.updatePhrase(phraseId, "Edited text")
+        val edited = useCase.getPhrasesForCategory(PresetCategories.GENERAL.id)
+            .first { it.phraseId == phraseId }
+        assertEquals(true, edited is CustomPhrase)
+
+        useCase.resetToDefaults()
+
+        val reset = useCase.getPhrasesForCategory(PresetCategories.GENERAL.id)
+        assertEquals(entryNames, reset.map { it.phraseId })
+        assertEquals(true, reset.first { it.phraseId == phraseId } is PresetPhrase)
+    }
+
+    @Test
+    fun reset_after_phrase_deletion_restores_preset_phrase() = runTest {
+        presetPhrasesRepository.populateDatabase()
+        val useCase = createUseCase()
+        val entryNames = getResourceNamesForCategory("category_general")
+        val phraseId = entryNames.first()
+
+        useCase.deletePhrase(phraseId)
+        assertEquals(
+            false,
+            useCase.getPhrasesForCategory(PresetCategories.GENERAL.id).any { it.phraseId == phraseId }
+        )
+
+        useCase.resetToDefaults()
+
+        assertEquals(entryNames, useCase.getPhrasesForCategory(PresetCategories.GENERAL.id).map { it.phraseId })
+    }
+
+    @Test
+    fun reset_after_custom_phrase_addition_removes_it() = runTest {
+        val useCase = createUseCase()
+        useCase.addPhrase(testLocalesWithText, PresetCategories.GENERAL.id)
+        assertEquals(1, useCase.getPhrasesForCategory(PresetCategories.GENERAL.id).size)
+
+        useCase.resetToDefaults()
+
+        val entryNames = getResourceNamesForCategory("category_general")
+        assertEquals(entryNames, useCase.getPhrasesForCategory(PresetCategories.GENERAL.id).map { it.phraseId })
+    }
+
+    @Test
+    fun reset_clears_recents() = runTest {
+        presetPhrasesRepository.populateDatabase()
+        val useCase = createUseCase()
+        storedPhrasesRepository.addPhrase(
+            PhraseDto(
+                phraseId = "custom1",
+                localizedUtterance = testLocalesWithText,
+                parentCategoryId = PresetCategories.GENERAL.id,
+                creationDate = 0L,
+                lastSpokenDate = 100L,
+                sortOrder = 0
+            )
+        )
+        dateProvider.time = 101L
+        presetPhrasesRepository.updatePhraseLastSpokenTime("category_123_0")
+        assertEquals(2, useCase.getPhrasesForCategory(PresetCategories.RECENTS.id).size)
+
+        useCase.resetToDefaults()
+
+        assertEquals(0, useCase.getPhrasesForCategory(PresetCategories.RECENTS.id).size)
     }
 
     private fun getResourceNamesForCategory(categoryName: String): List<String> {

--- a/app/src/main/java/com/willowtree/vocable/data/repository/PresetCategoriesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/PresetCategoriesRepository.kt
@@ -6,8 +6,10 @@ import kotlinx.coroutines.flow.Flow
 
 interface PresetCategoriesRepository {
     fun getPresetCategories(): Flow<List<Category>>
+    suspend fun populateDatabase()
     suspend fun updateCategorySortOrders(categorySortOrders: List<CategorySortOrder>)
     suspend fun getCategoryById(categoryId: String): Category.PresetCategory?
     suspend fun updateCategoryHidden(categoryId: String, hidden: Boolean)
     suspend fun deleteCategory(categoryId: String)
+    suspend fun deleteAllCategories()
 }

--- a/app/src/main/java/com/willowtree/vocable/data/repository/PresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/PresetPhrasesRepository.kt
@@ -13,4 +13,5 @@ interface PresetPhrasesRepository {
     fun getPhrasesForCategoryFlow(categoryId: String): Flow<List<PresetPhrase>>
     suspend fun getPhrase(phraseId: String): PresetPhrase?
     suspend fun deletePhrase(phraseId: String)
+    suspend fun deleteAllPhrases()
 }

--- a/app/src/main/java/com/willowtree/vocable/data/repository/RoomPresetCategoriesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/RoomPresetCategoriesRepository.kt
@@ -34,6 +34,10 @@ class RoomPresetCategoriesRepository(
         }.onStart { ensurePopulated() }
     }
 
+    override suspend fun populateDatabase() {
+        ensurePopulated()
+    }
+
     private suspend fun ensurePopulated() {
         categoryMutex.withLock {
             val dbPresets = database.presetCategoryDao().getAllPresetCategoriesFlow().first()
@@ -80,5 +84,9 @@ class RoomPresetCategoriesRepository(
     override suspend fun deleteCategory(categoryId: String) {
         ensurePopulated()
         database.presetCategoryDao().updateCategoryDeleted(PresetCategoryDeleted(categoryId, true))
+    }
+
+    override suspend fun deleteAllCategories() {
+        database.presetCategoryDao().deleteAllPresetCategories()
     }
 }

--- a/app/src/main/java/com/willowtree/vocable/data/repository/RoomPresetPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/RoomPresetPhrasesRepository.kt
@@ -70,6 +70,10 @@ class RoomPresetPhrasesRepository(
         presetPhrasesDao.deletePhrase(phraseId, deleted = true)
     }
 
+    override suspend fun deleteAllPhrases() {
+        presetPhrasesDao.deleteAllPresetPhrases()
+    }
+
     private fun List<PresetPhraseDto>.filterDeletedPresets(): List<PresetPhraseDto> {
         return filterNot { it.deleted }
     }

--- a/app/src/main/java/com/willowtree/vocable/data/repository/RoomStoredCategoriesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/RoomStoredCategoriesRepository.kt
@@ -41,4 +41,8 @@ class RoomStoredCategoriesRepository(
     override suspend fun deleteCategory(categoryId: String) {
         database.categoryDao().deleteCategory(categoryId)
     }
+
+    override suspend fun deleteAllCategories() {
+        database.categoryDao().deleteAllCategories()
+    }
 }

--- a/app/src/main/java/com/willowtree/vocable/data/repository/RoomStoredPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/RoomStoredPhrasesRepository.kt
@@ -61,4 +61,8 @@ class RoomStoredPhrasesRepository(
     override suspend fun deletePhrase(phraseId: String) {
         database.phraseDao().deletePhrase(phraseId)
     }
+
+    override suspend fun deleteAllPhrases() {
+        database.phraseDao().deleteAllPhrases()
+    }
 }

--- a/app/src/main/java/com/willowtree/vocable/data/repository/StoredCategoriesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/StoredCategoriesRepository.kt
@@ -12,4 +12,5 @@ interface StoredCategoriesRepository {
     suspend fun getCategoryById(categoryId: String): CategoryDto?
     suspend fun updateCategoryHidden(categoryId: String, hidden: Boolean)
     suspend fun deleteCategory(categoryId: String)
+    suspend fun deleteAllCategories()
 }

--- a/app/src/main/java/com/willowtree/vocable/data/repository/StoredPhrasesRepository.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/repository/StoredPhrasesRepository.kt
@@ -17,4 +17,5 @@ interface StoredPhrasesRepository {
         localizedUtterance: LocalesWithText,
     )
     suspend fun deletePhrase(phraseId: String)
+    suspend fun deleteAllPhrases()
 }

--- a/app/src/main/java/com/willowtree/vocable/data/room/CategoryDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/room/CategoryDao.kt
@@ -28,6 +28,9 @@ interface CategoryDao {
     @Query("DELETE FROM Category WHERE category_id = :categoryId")
     suspend fun deleteCategory(categoryId: String)
 
+    @Query("DELETE FROM Category")
+    suspend fun deleteAllCategories()
+
     @Update(entity = CategoryDto::class)
     suspend fun updateCategory(categoryLocalizedName: CategoryLocalizedName)
 

--- a/app/src/main/java/com/willowtree/vocable/data/room/PhraseDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/room/PhraseDao.kt
@@ -20,6 +20,9 @@ interface PhraseDao {
     @Query("DELETE FROM Phrase WHERE phrase_id == :phraseId")
     suspend fun deletePhrase(phraseId: String)
 
+    @Query("DELETE FROM Phrase")
+    suspend fun deleteAllPhrases()
+
     @Delete
     suspend fun deletePhrases(vararg phrases: PhraseDto)
 

--- a/app/src/main/java/com/willowtree/vocable/data/room/PresetCategoryDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/room/PresetCategoryDao.kt
@@ -25,4 +25,7 @@ interface PresetCategoryDao {
 
     @Update(entity = PresetCategoryDto::class)
     suspend fun updateCategoryDeleted(categoryDeleted: PresetCategoryDeleted)
+
+    @Query("DELETE FROM PresetCategory")
+    suspend fun deleteAllPresetCategories()
 }

--- a/app/src/main/java/com/willowtree/vocable/data/room/PresetPhrasesDao.kt
+++ b/app/src/main/java/com/willowtree/vocable/data/room/PresetPhrasesDao.kt
@@ -36,4 +36,7 @@ interface PresetPhrasesDao {
 
     @Query("UPDATE PresetPhrase SET deleted = :deleted WHERE phrase_id = :phraseId")
     suspend fun deletePhrase(phraseId: String, deleted: Boolean)
+
+    @Query("DELETE FROM PresetPhrase")
+    suspend fun deleteAllPresetPhrases()
 }

--- a/app/src/main/java/com/willowtree/vocable/domain/usecase/CategoriesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/domain/usecase/CategoriesUseCase.kt
@@ -148,4 +148,10 @@ class CategoriesUseCase(
         )
     }
 
+    override suspend fun resetToDefaults() {
+        phrasesUseCase.resetToDefaults()
+        storedCategoriesRepository.deleteAllCategories()
+        presetCategoriesRepository.deleteAllCategories()
+        presetCategoriesRepository.populateDatabase()
+    }
 }

--- a/app/src/main/java/com/willowtree/vocable/domain/usecase/ICategoriesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/domain/usecase/ICategoriesUseCase.kt
@@ -15,4 +15,5 @@ interface ICategoriesUseCase {
     suspend fun deleteCategory(categoryId: String)
     suspend fun moveCategoryUp(categoryId: String)
     suspend fun moveCategoryDown(categoryId: String)
+    suspend fun resetToDefaults()
 }

--- a/app/src/main/java/com/willowtree/vocable/domain/usecase/IPhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/domain/usecase/IPhrasesUseCase.kt
@@ -17,4 +17,6 @@ interface IPhrasesUseCase {
     suspend fun updatePhrase(phraseId: String, updatedPhrase: String)
 
     suspend fun addPhrase(localizedUtterance: LocalesWithText, parentCategoryId: String)
+
+    suspend fun resetToDefaults()
 }

--- a/app/src/main/java/com/willowtree/vocable/domain/usecase/PhrasesUseCase.kt
+++ b/app/src/main/java/com/willowtree/vocable/domain/usecase/PhrasesUseCase.kt
@@ -105,4 +105,10 @@ class PhrasesUseCase(
             )
         }
     }
+
+    override suspend fun resetToDefaults() {
+        storedPhrasesRepository.deleteAllPhrases()
+        presetPhrasesRepository.deleteAllPhrases()
+        presetPhrasesRepository.populateDatabase()
+    }
 }

--- a/app/src/test/java/com/willowtree/vocable/FakeCategoriesUseCase.kt
+++ b/app/src/test/java/com/willowtree/vocable/FakeCategoriesUseCase.kt
@@ -123,4 +123,8 @@ class FakeCategoriesUseCase : ICategoriesUseCase {
     override suspend fun moveCategoryDown(categoryId: String) {
         TODO("Not yet implemented")
     }
+
+    override suspend fun resetToDefaults() {
+        TODO("Not yet implemented")
+    }
 }

--- a/app/src/test/java/com/willowtree/vocable/FakePhrasesUseCase.kt
+++ b/app/src/test/java/com/willowtree/vocable/FakePhrasesUseCase.kt
@@ -58,4 +58,8 @@ class FakePhrasesUseCase : IPhrasesUseCase {
     override suspend fun addPhrase(localizedUtterance: LocalesWithText, parentCategoryId: String) {
         error("Not implemented")
     }
+
+    override suspend fun resetToDefaults() {
+        error("Not implemented")
+    }
 }


### PR DESCRIPTION
## Summary
- Added bulk `deleteAll*()` queries to `CategoryDao`, `PhraseDao`, `PresetCategoryDao`, `PresetPhrasesDao` — none of the four had a "delete everything" query before
- Added a public `populateDatabase()` on `RoomPresetCategoriesRepository`, mirroring the one that already existed on `RoomPresetPhrasesRepository`, so reseeding categories can be triggered deterministically instead of only implicitly via flow subscription
- Added `resetToDefaults()` to `ICategoriesUseCase`/`IPhrasesUseCase`. `PhrasesUseCase.resetToDefaults()` wipes stored+preset phrases and re-seeds; `CategoriesUseCase.resetToDefaults()` delegates to `phrasesUseCase.resetToDefaults()` (reusing the same collaborator `deleteCategory` already uses to cascade phrase deletion), then wipes+reseeds categories — so `categoriesUseCase.resetToDefaults()` is the single entry point #640 needs for the reset button
- 7 new androidTest cases: reset after category edit / deletion / custom addition, reset after phrase edit / deletion / custom addition, and Recents clearing after reset

## Ticket
Part of #627 — closes #639

This PR targets `feature/638/reset-preference-wipe` (not `feature/voice-selection` or `main`) to avoid rebase/merge churn while both #638 and #639 are in flight under the same epic. `closes #639` won't auto-fire on merge into a non-default branch — will close manually with a link to this PR once merged.

Full details, including why Recents-clearing needed its own explicit test and a known gap (no Compose UI test yet, since there's no reset button until #640) in `Documentation/work-log/639-reset-category-phrase-reseed.md`.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] CI/CD
- [x] Documentation

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

## Checklist
- [x] Tests pass locally (`./gradlew testDebug`) — also ran the full `connectedDebugAndroidTest` suite on-device (55 tests, 0 failed)
- [x] No API keys or secrets in code
- [ ] CLAUDE.md updated (if new pattern introduced)